### PR TITLE
Allow mixing multiple universes in a story

### DIFF
--- a/packages/api/src/routes/create-story-schema.ts
+++ b/packages/api/src/routes/create-story-schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { PIPELINE_STAGES, PipelineStage } from '@bedtime/core/pipeline/pipeline-stages'
 import { getStoryStructureByKey } from '@bedtime/core/pipeline/stages/story-structures'
 import { getCharacterLensByKey } from '@bedtime/core/pipeline/stages/character-lenses'
+import { MAX_UNIVERSES_PER_STORY } from './story-universe-links'
 
 const stageOverrideSchema = z.object({
   model: z.string().min(1),
@@ -26,6 +27,7 @@ export const createStorySchema = z
     title: z.string().min(1).max(200).optional(),
     textFinal: z.string().min(1).optional(),
     groupId: z.number().int().positive().optional(),
+    groupIds: z.array(z.number().int().positive()).min(1).max(MAX_UNIVERSES_PER_STORY).optional(),
     pipelineMode: z.enum(['auto', 'manual']).optional(),
     source: z.enum(['user', 'legacy']).optional(),
     addToReadingList: z.boolean().optional(),
@@ -64,6 +66,7 @@ export type CreateStoryMode =
       seed: string
       title: string
       groupId?: number
+      groupIds?: number[]
       pipelineMode?: 'auto' | 'manual'
       perStageOverrides?: PerStageOverrides
       structureKey?: string
@@ -101,8 +104,15 @@ export function resolveCreateStoryMode(input: CreateStoryInput): CreateStoryMode
   const title = seed.trim().slice(0, 60)
   const result: CreateStoryMode = { mode: 'agent', seed, title }
 
-  if (input.groupId !== undefined) {
-    result.groupId = input.groupId
+  const groupIds = input.groupIds !== undefined
+    ? Array.from(new Set(input.groupIds))
+    : input.groupId !== undefined ? [input.groupId] : undefined
+
+  const [primaryGroupId] = groupIds ?? []
+
+  if (groupIds !== undefined && primaryGroupId !== undefined) {
+    result.groupIds = groupIds
+    result.groupId = primaryGroupId
   }
 
   if (input.pipelineMode !== undefined) {

--- a/packages/api/src/routes/internal-backfill.ts
+++ b/packages/api/src/routes/internal-backfill.ts
@@ -5,6 +5,7 @@ import { stories } from '@bedtime/core/db/schema'
 import type { PipelineInternalStatus } from './pipeline-status'
 import { getPipelineStatus } from './pipeline-state'
 import { dispatchAutoPipeline } from './pipeline-dispatch'
+import { getStoryUniverseIds } from './story-universe-links'
 
 const RETRIABLE_STATUSES: ReadonlySet<PipelineInternalStatus> = new Set([
   'plan_failed',
@@ -60,7 +61,9 @@ router.post('/', async (req, res) => {
         continue
       }
 
-      void dispatchAutoPipeline({ storyId: story.id, seed: story.seed as string, universeId: story.groupId ?? null }).catch((err) => {
+      const universeIds = await getStoryUniverseIds(story.id, story.groupId)
+
+      void dispatchAutoPipeline({ storyId: story.id, seed: story.seed as string, universeIds }).catch((err) => {
         console.error(`Failed to dispatch auto pipeline for storyId=${story.id}:`, err)
       })
       triggered.push(story.id)

--- a/packages/api/src/routes/internal-worker.ts
+++ b/packages/api/src/routes/internal-worker.ts
@@ -14,7 +14,7 @@ const pipelineTaskSchema = z.object({
   universeSystemPrompt: z.string().optional(),
   universeContext: z.string().optional(),
   styleGuide: z.string().optional(),
-  universeId: z.number().int().nullable().optional(),
+  universeIds: z.array(z.number().int()).optional(),
 })
 
 const analyzeTaskSchema = z.object({

--- a/packages/api/src/routes/load-universe-context.ts
+++ b/packages/api/src/routes/load-universe-context.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { inArray } from 'drizzle-orm'
 import { db } from '@bedtime/core/db/client'
 import { storyGroups, universeCharacters } from '@bedtime/core/db/schema'
 import type { CharacterBibleEntry } from '@bedtime/core/pipeline/stages/character-bible-block'
@@ -8,6 +8,13 @@ interface UniverseContext {
   universeContext: string | undefined
   styleGuide: string | undefined
   bibleCharacters: CharacterBibleEntry[]
+}
+
+const EMPTY_CONTEXT: UniverseContext = {
+  universeSystemPrompt: undefined,
+  universeContext: undefined,
+  styleGuide: undefined,
+  bibleCharacters: [],
 }
 
 function compileCharacters(chars: Array<{ name: string; description: string }>): string {
@@ -20,19 +27,26 @@ function compileCharacters(chars: Array<{ name: string; description: string }>):
   return `## Персонажи вселенной\n${lines.join('\n')}`
 }
 
-export async function loadUniverseContext(groupId: number): Promise<UniverseContext> {
-  const [[group], chars] = await Promise.all([
-    db.select().from(storyGroups).where(eq(storyGroups.id, groupId)),
-    db.select().from(universeCharacters).where(eq(universeCharacters.universeId, groupId)),
+export async function loadUniverseContext(universeIds: number[]): Promise<UniverseContext> {
+  const ids = Array.from(new Set(universeIds))
+
+  if (ids.length === 0) return EMPTY_CONTEXT
+
+  const [groups, chars] = await Promise.all([
+    db.select().from(storyGroups).where(inArray(storyGroups.id, ids)),
+    db.select().from(universeCharacters).where(inArray(universeCharacters.universeId, ids)),
   ])
 
-  if (!group) {
-    return { universeSystemPrompt: undefined, universeContext: undefined, styleGuide: undefined, bibleCharacters: [] }
-  }
+  if (groups.length === 0) return EMPTY_CONTEXT
 
-  const characterBlock = compileCharacters(chars)
-  const baseContext = group.universeContext?.trim() ?? ''
-  const universeContext = [baseContext, characterBlock].filter(Boolean).join('\n\n') || undefined
+  const isBlend = groups.length > 1
+  const charsByUniverse = new Map<number, typeof chars>()
+
+  for (const c of chars) {
+    const bucket = charsByUniverse.get(c.universeId) ?? []
+    bucket.push(c)
+    charsByUniverse.set(c.universeId, bucket)
+  }
 
   const bibleCharacters: CharacterBibleEntry[] = chars.map((c) => ({
     name: c.name,
@@ -44,10 +58,49 @@ export async function loadUniverseContext(groupId: number): Promise<UniverseCont
     description: c.description,
   }))
 
+  if (!isBlend) {
+    const [group] = groups
+    const group1Chars = charsByUniverse.get(group!.id) ?? []
+    const characterBlock = compileCharacters(group1Chars)
+    const baseContext = group!.universeContext?.trim() ?? ''
+    const universeContext = [baseContext, characterBlock].filter(Boolean).join('\n\n') || undefined
+
+    return {
+      universeSystemPrompt: group!.systemPrompt,
+      universeContext,
+      styleGuide: group!.styleGuide ?? undefined,
+      bibleCharacters,
+    }
+  }
+
+  const systemPromptBlocks: string[] = []
+  const contextBlocks: string[] = []
+  const styleGuideBlocks: string[] = []
+
+  groups.forEach((group, index) => {
+    const label = `Вселенная ${index + 1}: ${group.name}`
+
+    systemPromptBlocks.push(`## ${label}\n${group.systemPrompt}`)
+
+    const characterBlock = compileCharacters(charsByUniverse.get(group.id) ?? [])
+    const baseContext = group.universeContext?.trim() ?? ''
+    const combined = [baseContext, characterBlock].filter(Boolean).join('\n\n')
+
+    if (combined) {
+      contextBlocks.push(`## ${label}\n${combined}`)
+    }
+
+    if (group.styleGuide) {
+      styleGuideBlocks.push(`## ${label}\n${group.styleGuide}`)
+    }
+  })
+
+  const blendPreamble = 'СМЕШЕНИЕ ВСЕЛЕННЫХ: эта история намеренно объединяет несколько вселенных, перечисленных ниже. Продумай, как их персонажи, тон и правила мира переплетаются между собой — не выбирай только одну вселенную и не игнорируй остальные.'
+
   return {
-    universeSystemPrompt: group.systemPrompt,
-    universeContext,
-    styleGuide: group.styleGuide ?? undefined,
+    universeSystemPrompt: `${blendPreamble}\n\n${systemPromptBlocks.join('\n\n')}`,
+    universeContext: contextBlocks.length > 0 ? contextBlocks.join('\n\n') : undefined,
+    styleGuide: styleGuideBlocks.length > 0 ? styleGuideBlocks.join('\n\n') : undefined,
     bibleCharacters,
   }
 }

--- a/packages/api/src/routes/pipeline-auto-trigger.ts
+++ b/packages/api/src/routes/pipeline-auto-trigger.ts
@@ -20,11 +20,12 @@ export interface AutoPipelineParams {
   universeSystemPrompt?: string | undefined
   universeContext?: string | undefined
   styleGuide?: string | undefined
-  universeId?: number | null | undefined
+  universeIds?: number[] | undefined
 }
 
 export async function runAutoPipeline(params: AutoPipelineParams): Promise<void> {
-  const { storyId, seed, universeSystemPrompt, universeContext, styleGuide, universeId = null } = params
+  const { storyId, seed, universeSystemPrompt, universeContext, styleGuide, universeIds = [] } = params
+  const primaryUniverseId = universeIds[0] ?? null
 
   setPipelineStatus(storyId, 'plan_running')
 
@@ -38,8 +39,8 @@ export async function runAutoPipeline(params: AutoPipelineParams): Promise<void>
     try {
       const [sasha, models, enrichedContext] = await Promise.all([
         synthesizeSashaContext(),
-        loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(universeId, overrides)),
-        universeId !== null ? loadUniverseContext(universeId) : Promise.resolve(null),
+        loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(primaryUniverseId, overrides)),
+        loadUniverseContext(universeIds),
       ])
 
       sashaContext = sasha
@@ -53,7 +54,7 @@ export async function runAutoPipeline(params: AutoPipelineParams): Promise<void>
         storyId,
         models,
         promptVersions: defaultPromptVersions,
-        universeId,
+        universeIds,
         injectFragments: true,
         ...(effectiveSystemPrompt !== undefined ? { universeSystemPrompt: effectiveSystemPrompt } : {}),
         ...(effectiveUniverseContext !== undefined ? { universeContext: effectiveUniverseContext } : {}),
@@ -83,7 +84,7 @@ export async function runAutoPipeline(params: AutoPipelineParams): Promise<void>
       sashaContext,
       universeContext: effectiveUniverseContext,
       styleGuide: effectiveStyleGuide,
-      universeId,
+      universeIds,
     })
   })
 }

--- a/packages/api/src/routes/pipeline-plan-redo.ts
+++ b/packages/api/src/routes/pipeline-plan-redo.ts
@@ -35,17 +35,18 @@ export function triggerPlanRedo(
   universeSystemPrompt?: string,
   universeContext?: string,
   styleGuide?: string,
-  universeId: number | null = null,
+  universeIds: number[] = [],
   reason?: string,
   modelOverride?: string,
 ): void {
   setPipelineStatus(storyId, 'plan_running')
+  const primaryUniverseId = universeIds[0] ?? null
 
   withPipelineTrace(String(storyId), async () => {
     const [feedback, models, ctx] = await Promise.all([
-      gatherRedoFeedback({ storyId, context: 'plan', reason, universeId }),
-      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(universeId, overrides)),
-      universeId != null ? loadUniverseContext(universeId) : Promise.resolve(null),
+      gatherRedoFeedback({ storyId, context: 'plan', reason, universeId: primaryUniverseId }),
+      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(primaryUniverseId, overrides)),
+      loadUniverseContext(universeIds),
     ])
 
     if (modelOverride) {
@@ -68,7 +69,7 @@ export function triggerPlanRedo(
       ...(sashaContext !== null ? { sashaContext } : {}),
       ...(userFeedback ? { userFeedback } : {}),
       ...(bibleCharacters.length > 0 ? { bibleCharacters } : {}),
-      universeId,
+      universeIds,
       onStepChange: (step) => setCurrentStep(storyId, step),
     })
 

--- a/packages/api/src/routes/pipeline-plan-trigger.ts
+++ b/packages/api/src/routes/pipeline-plan-trigger.ts
@@ -33,7 +33,7 @@ export function triggerPlanPhaseFromAnswers(
   universeSystemPrompt?: string,
   universeContext?: string,
   styleGuide?: string,
-  universeId: number | null = null,
+  universeIds: number[] = [],
   bibleCharacters: CharacterBibleEntry[] = [],
 ): void {
   setPipelineStatus(storyId, 'questions_answered')
@@ -43,11 +43,12 @@ export function triggerPlanPhaseFromAnswers(
     .join('\n')
 
   const seedWithAnswers = `SEED: ${seed}\n\nCLARIFYING Q&A:\n${qaBlock}`
+  const primaryUniverseId = universeIds[0] ?? null
 
   withPipelineTrace(String(storyId), async () => {
     const [sashaContext, models] = await Promise.all([
       synthesizeSashaContext(),
-      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(universeId, overrides)),
+      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(primaryUniverseId, overrides)),
     ])
 
     const result = await runPlotterOnly({
@@ -55,7 +56,7 @@ export function triggerPlanPhaseFromAnswers(
       storyId,
       models,
       promptVersions: defaultPromptVersions,
-      universeId,
+      universeIds,
       injectFragments: true,
       ...(universeSystemPrompt !== undefined ? { universeSystemPrompt } : {}),
       ...(universeContext !== undefined ? { universeContext } : {}),

--- a/packages/api/src/routes/pipeline-questions.ts
+++ b/packages/api/src/routes/pipeline-questions.ts
@@ -5,6 +5,7 @@ import { validate } from '../middleware/validate'
 import { db } from '@bedtime/core/db/client'
 import { planQuestions, planConversations, stories, storyGroups, storyTextVersions, annotations } from '@bedtime/core/db/schema'
 import { loadUniverseContext } from './load-universe-context'
+import { getStoryUniverseIds } from './story-universe-links'
 import { aiRunner } from '@bedtime/core/ai'
 import { triggerPlanPhaseFromAnswers } from './pipeline-plan-trigger'
 import { resolveChatGate } from '@bedtime/core/pipeline/resolve-chat-gate'
@@ -90,9 +91,8 @@ router.post('/questions/:storyId/submit', validate(submitAnswersSchema), async (
 
     const seed = storyRow.seed ?? ''
 
-    const { universeSystemPrompt, universeContext, styleGuide, bibleCharacters } = storyRow.groupId != null
-      ? await loadUniverseContext(storyRow.groupId)
-      : { universeSystemPrompt: undefined, universeContext: undefined, styleGuide: undefined, bibleCharacters: [] }
+    const universeIds = await getStoryUniverseIds(storyIdRaw, storyRow.groupId)
+    const { universeSystemPrompt, universeContext, styleGuide, bibleCharacters } = await loadUniverseContext(universeIds)
 
     const updatedQuestions = await db
       .select()
@@ -103,7 +103,7 @@ router.post('/questions/:storyId/submit', validate(submitAnswersSchema), async (
       .filter((q) => q.answerText !== null && q.answerText !== undefined)
       .map((q) => ({ question: q.questionText, answer: q.answerText ?? '' }))
 
-    triggerPlanPhaseFromAnswers(storyIdRaw, seed, qaArray, universeSystemPrompt, universeContext, styleGuide, storyRow.groupId ?? null, bibleCharacters)
+    triggerPlanPhaseFromAnswers(storyIdRaw, seed, qaArray, universeSystemPrompt, universeContext, styleGuide, universeIds, bibleCharacters)
 
     res.json({ ok: true })
   } catch (err) {
@@ -144,11 +144,10 @@ router.post('/questions/:storyId/retry-plan', async (req, res) => {
 
     const seed = storyRow.seed ?? ''
 
-    const { universeSystemPrompt: usp2, universeContext: uc2, styleGuide: sg2, bibleCharacters: bc2 } = storyRow.groupId != null
-      ? await loadUniverseContext(storyRow.groupId)
-      : { universeSystemPrompt: undefined, universeContext: undefined, styleGuide: undefined, bibleCharacters: [] }
+    const universeIds2 = await getStoryUniverseIds(storyIdRaw, storyRow.groupId)
+    const { universeSystemPrompt: usp2, universeContext: uc2, styleGuide: sg2, bibleCharacters: bc2 } = await loadUniverseContext(universeIds2)
 
-    triggerPlanPhaseFromAnswers(storyIdRaw, seed, qaArray, usp2, uc2, sg2, storyRow.groupId ?? null, bc2)
+    triggerPlanPhaseFromAnswers(storyIdRaw, seed, qaArray, usp2, uc2, sg2, universeIds2, bc2)
 
     res.json({ ok: true, storyId: storyIdRaw })
   } catch (err) {

--- a/packages/api/src/routes/pipeline-text-redo.ts
+++ b/packages/api/src/routes/pipeline-text-redo.ts
@@ -23,15 +23,16 @@ export function triggerTextRedoWithAnnotations(
   universeSystemPrompt?: string,
   universeContext?: string,
   styleGuide?: string,
-  universeId: number | null = null,
+  universeIds: number[] = [],
 ): void {
   setPipelineStatus(storyId, 'plan_running')
+  const primaryUniverseId = universeIds[0] ?? null
 
   withPipelineTrace(String(storyId), async () => {
     const [sashaContext, models, ctx] = await Promise.all([
       synthesizeSashaContext(),
-      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(universeId, overrides)),
-      universeId != null ? loadUniverseContext(universeId) : Promise.resolve(null),
+      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(primaryUniverseId, overrides)),
+      loadUniverseContext(universeIds),
     ])
 
     const bibleCharacters = ctx?.bibleCharacters ?? []
@@ -64,7 +65,7 @@ export function triggerTextRedoWithAnnotations(
       ...(universeContext !== undefined ? { universeContext } : {}),
       ...(styleGuide !== undefined ? { styleGuide } : {}),
       ...(sashaContext !== null && sashaContext !== undefined ? { sashaContext } : {}),
-      universeId,
+      universeIds,
       onStepChange: (step) => setCurrentStep(storyId, step),
     })
 

--- a/packages/api/src/routes/pipeline-text-rewrite.ts
+++ b/packages/api/src/routes/pipeline-text-rewrite.ts
@@ -16,17 +16,18 @@ export function triggerTextRewrite(
   universeContext?: string,
   styleGuide?: string,
   sashaContext?: string | null,
-  universeId: number | null = null,
+  universeIds: number[] = [],
   activeTextVersionId?: number | null,
   reason?: string,
   modelOverride?: string,
 ): void {
   setPipelineStatus(storyId, 'text_running')
+  const primaryUniverseId = universeIds[0] ?? null
 
   withPipelineTraceIfNone(String(storyId), async () => {
     const [feedback, models] = await Promise.all([
-      gatherRedoFeedback({ storyId, context: 'text', reason, universeId, activeTextVersionId }),
-      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(universeId, overrides)),
+      gatherRedoFeedback({ storyId, context: 'text', reason, universeId: primaryUniverseId, activeTextVersionId }),
+      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(primaryUniverseId, overrides)),
     ])
 
     if (modelOverride) {

--- a/packages/api/src/routes/pipeline-text-trigger.ts
+++ b/packages/api/src/routes/pipeline-text-trigger.ts
@@ -25,7 +25,7 @@ export interface TextPhaseParams {
   sashaContext?: string | null | undefined
   universeContext?: string | undefined
   styleGuide?: string | undefined
-  universeId?: number | null | undefined
+  universeIds?: number[] | undefined
   currentText?: string | undefined
   activeTextVersionId?: number | null | undefined
 }
@@ -40,10 +40,11 @@ export async function runTextPhaseDurable(params: TextPhaseParams): Promise<void
     sashaContext,
     universeContext,
     styleGuide,
-    universeId = null,
+    universeIds = [],
     currentText,
     activeTextVersionId,
   } = params
+  const primaryUniverseId = universeIds[0] ?? null
 
   setPipelineStatus(storyId, 'text_running')
 
@@ -64,8 +65,8 @@ export async function runTextPhaseDurable(params: TextPhaseParams): Promise<void
         .select({ selectedText: annotations.selectedText, noteText: annotations.noteText })
         .from(annotations)
         .where(and(eq(annotations.storyId, storyId), eq(annotations.context, annotationContext), versionFilter)),
-      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(universeId, overrides)),
-      isRetry ? Promise.resolve([]) : loadRandomExemplars(universeId, 2),
+      loadStoryOverrides(storyId).then((overrides) => resolvePipelineModels(primaryUniverseId, overrides)),
+      isRetry ? Promise.resolve([]) : loadRandomExemplars(universeIds, 2),
     ])
 
     const userAnnotations = rows
@@ -79,7 +80,7 @@ export async function runTextPhaseDurable(params: TextPhaseParams): Promise<void
 
     const [chosenFragments, targetWords] = await Promise.all([
       isRetry ? Promise.resolve([]) : loadStoryFragmentTexts(storyId),
-      isRetry ? Promise.resolve([]) : loadEligibleWords(universeId),
+      isRetry ? Promise.resolve([]) : loadEligibleWords(universeIds),
     ])
 
     if (chosenFragments.length > 0) {
@@ -105,7 +106,7 @@ export async function runTextPhaseDurable(params: TextPhaseParams): Promise<void
       ...(targetWords.length > 0 ? { targetWords } : {}),
       ...(isRetry ? { previousText: currentText } : {}),
       ...(userAnnotations ? { userAnnotations } : {}),
-      universeId,
+      universeIds,
       onStepChange: (step) => setCurrentStep(storyId, step),
       onChunk: (chunk) => emitPipelineEvent(storyId, { type: 'chunk', text: chunk }),
       onChunkReset: () => emitPipelineEvent(storyId, { type: 'chunk_reset' }),
@@ -160,7 +161,7 @@ export function triggerTextPhase(
   sashaContext?: string | null,
   universeContext?: string,
   styleGuide?: string,
-  universeId: number | null = null,
+  universeIds: number[] = [],
   currentText?: string,
   activeTextVersionId?: number | null,
 ): void {
@@ -173,7 +174,7 @@ export function triggerTextPhase(
     sashaContext,
     universeContext,
     styleGuide,
-    universeId,
+    universeIds,
     currentText,
     activeTextVersionId,
   }).catch((textError) => {

--- a/packages/api/src/routes/pipeline.ts
+++ b/packages/api/src/routes/pipeline.ts
@@ -9,7 +9,9 @@ import {
 } from '@bedtime/core/pipeline/orchestrator'
 import { synthesizeSashaContext } from '@bedtime/core/pipeline/feedback-synthesizer'
 import { db } from '@bedtime/core/db/client'
-import { runSnapshots, stories, storyGroups, planQuestions } from '@bedtime/core/db/schema'
+import { runSnapshots, stories, planQuestions } from '@bedtime/core/db/schema'
+import { loadUniverseContext } from './load-universe-context'
+import { getStoryUniverseIds } from './story-universe-links'
 import {
   toPublicStatus,
   type PipelineInternalStatus,
@@ -81,24 +83,13 @@ router.post('/run', validate(runPipelineSchema), async (req, res) => {
       return
     }
 
-    let universeSystemPrompt: string | undefined
-    let universeContext: string | undefined
-    let styleGuide: string | undefined
-
-    if (storyRow.groupId !== null && storyRow.groupId !== undefined) {
-      const [group] = await db.select().from(storyGroups).where(eq(storyGroups.id, storyRow.groupId))
-
-      if (group) {
-        universeSystemPrompt = group.systemPrompt
-        universeContext = group.universeContext ?? undefined
-        styleGuide = group.styleGuide ?? undefined
-      }
-    }
+    const universeIds = await getStoryUniverseIds(storyId, storyRow.groupId)
+    const { universeSystemPrompt, universeContext, styleGuide } = await loadUniverseContext(universeIds)
 
     const mode = storyRow.mode ?? 'auto'
 
     if (mode === 'auto') {
-      await dispatchAutoPipeline({ storyId, seed, universeSystemPrompt, universeContext, styleGuide, universeId: storyRow.groupId ?? null })
+      await dispatchAutoPipeline({ storyId, seed, universeSystemPrompt, universeContext, styleGuide, universeIds })
       res.json({ started: true, storyId, phase: 'auto' })
       return
     }

--- a/packages/api/src/routes/stories-series.ts
+++ b/packages/api/src/routes/stories-series.ts
@@ -12,6 +12,7 @@ import { synthesizeSashaContext } from '@bedtime/core/pipeline/feedback-synthesi
 import type { CharacterBibleEntry } from '@bedtime/core/pipeline/stages/character-bible-block'
 import { resolvePipelineModels } from './pipeline-defaults'
 import { loadUniverseContext } from './load-universe-context'
+import { setStoryUniverses } from './story-universe-links'
 import { withPipelineTrace } from '@bedtime/observability'
 
 const router = Router()
@@ -37,7 +38,7 @@ router.post('/', validate(createSeriesSchema), async (req, res) => {
         universeSystemPrompt = group.systemPrompt
         universeContext = group.universeContext ?? undefined
         styleGuide = group.styleGuide ?? undefined
-        bibleCharacters = (await loadUniverseContext(groupId)).bibleCharacters
+        bibleCharacters = (await loadUniverseContext([groupId])).bibleCharacters
       }
     }
 
@@ -47,7 +48,7 @@ router.post('/', validate(createSeriesSchema), async (req, res) => {
       const [sashaContext, resolvedModels, eligibleFragments] = await Promise.all([
         synthesizeSashaContext(),
         resolvePipelineModels(groupId ?? null, null),
-        loadEligibleFragments(groupId ?? null),
+        loadEligibleFragments(groupId !== undefined ? [groupId] : []),
       ])
 
       const resolvedPlans = await runPlotterSeries({
@@ -90,6 +91,10 @@ router.post('/', validate(createSeriesSchema), async (req, res) => {
         return recordStoryFragments(row.id, ids)
       }),
     )
+
+    if (groupId !== undefined) {
+      await Promise.all(created.map((row) => setStoryUniverses(row.id, [groupId])))
+    }
 
     res.status(201).json({
       seriesId,

--- a/packages/api/src/routes/stories-swap-model.ts
+++ b/packages/api/src/routes/stories-swap-model.ts
@@ -2,10 +2,12 @@ import { Router, type Request } from 'express'
 import { z } from 'zod'
 import { eq, desc } from 'drizzle-orm'
 import { db } from '@bedtime/core/db/client'
-import { stories, storyGroups, runSnapshots, modelSwapEvents } from '@bedtime/core/db/schema'
+import { stories, runSnapshots, modelSwapEvents } from '@bedtime/core/db/schema'
 import { validate } from '../middleware/validate'
 import { triggerPlanRedo } from './pipeline-plan-redo'
 import { triggerTextPhase } from './pipeline-text-trigger'
+import { getStoryUniverseIds } from './story-universe-links'
+import { loadUniverseContext } from './load-universe-context'
 import type { StageOverrides } from '@bedtime/core/pipeline/derivers/per-stage-models'
 
 const ORCHESTRATOR_STAGES = ['plotter', 'writer'] as const
@@ -82,18 +84,8 @@ router.post('/', validate(swapModelSchema), async (req: Request<StoryParams>, re
 
     console.log(`[swap] story_id=${storyId} stage=${stage} from=${fromModel ?? 'none'} to=${body.toModel} chip=${body.reasonChip ?? 'none'}`)
 
-    let universeSystemPrompt: string | undefined
-    let universeContext: string | undefined
-    let styleGuide: string | undefined
-
-    if (storyRow.groupId !== null && storyRow.groupId !== undefined) {
-      const [group] = await db.select().from(storyGroups).where(eq(storyGroups.id, storyRow.groupId)).limit(1)
-      if (group) {
-        universeSystemPrompt = group.systemPrompt
-        universeContext = group.universeContext ?? undefined
-        styleGuide = group.styleGuide ?? undefined
-      }
-    }
+    const universeIds = await getStoryUniverseIds(storyId, storyRow.groupId)
+    const { universeSystemPrompt, universeContext, styleGuide } = await loadUniverseContext(universeIds)
 
     setImmediate(() => {
       if (stage === 'plotter') {
@@ -104,7 +96,7 @@ router.post('/', validate(swapModelSchema), async (req: Request<StoryParams>, re
           universeSystemPrompt,
           universeContext,
           styleGuide,
-          storyRow.groupId ?? null,
+          universeIds,
         )
       } else {
         triggerTextPhase(
@@ -116,7 +108,7 @@ router.post('/', validate(swapModelSchema), async (req: Request<StoryParams>, re
           null,
           universeContext,
           styleGuide,
-          storyRow.groupId ?? null,
+          universeIds,
           storyRow.textV1 ?? undefined,
           storyRow.activeTextVersionId ?? null,
         )

--- a/packages/api/src/routes/stories.ts
+++ b/packages/api/src/routes/stories.ts
@@ -2,7 +2,7 @@ import { Router } from 'express'
 import { z } from 'zod'
 import { eq, desc, and, sql } from 'drizzle-orm'
 import { db } from '@bedtime/core/db/client'
-import { stories, annotations, feedback, runSnapshots, storyGroups, planQuestions, planConversations, parentReviews, childReactions, storyReadings, modelCalls, storyTextVersions } from '@bedtime/core/db/schema'
+import { stories, annotations, feedback, runSnapshots, storyGroups, planQuestions, planConversations, parentReviews, childReactions, storyReadings, modelCalls, storyTextVersions, storyUniverses } from '@bedtime/core/db/schema'
 import { deriveStoryCostBreakdown } from '@bedtime/core/cost/aggregations/derive-story-cost-breakdown'
 import type { Story, NewStory, NewAnnotation, ParentReview, ChildReaction } from '@bedtime/core/db/types'
 import { validate } from '../middleware/validate'
@@ -15,6 +15,7 @@ import { createStorySchema, resolveCreateStoryMode } from './create-story-schema
 import { analyzeStoryAndLearn } from './story-analysis'
 import { dispatchAnalysis } from './pipeline-dispatch'
 import { loadUniverseContext } from './load-universe-context'
+import { getStoryUniverseIds, getStoryUniverseIdsBatch, setStoryUniverses } from './story-universe-links'
 import { loadStoryFragmentTexts } from '@bedtime/core/pipeline/load-fragments'
 import { syncUniverseMemory } from '@bedtime/core/pipeline/synthesize-universe-memory'
 import { notifyStoryReady } from './pipeline-notifications'
@@ -140,6 +141,10 @@ router.post('/', validate(createStorySchema), async (req, res) => {
     }
     const [story] = await db.insert(stories).values(newStory).returning()
 
+    if (resolved.groupIds !== undefined && resolved.groupIds.length > 0) {
+      await setStoryUniverses((story as Story).id, resolved.groupIds)
+    }
+
     res.status(201).json(toSnakeCase(story as Story))
   } catch (err) {
     console.error('POST /stories failed:', err)
@@ -193,7 +198,7 @@ router.get('/tags', async (_req, res) => {
 
 router.get('/', async (req, res) => {
   try {
-    const { status, groupId, tag, sort } = req.query
+    const { status, groupId, tag, sort, mixedOnly } = req.query
 
     if (status !== undefined && typeof status !== 'string') {
       res.status(400).json({ error: 'Invalid status filter' })
@@ -210,12 +215,16 @@ router.get('/', async (req, res) => {
       const gid = parseInt(groupId, 10)
 
       if (!isNaN(gid)) {
-        conditions.push(eq(stories.groupId, gid))
+        conditions.push(sql`(${stories.groupId} = ${gid} or exists (select 1 from story_universes where story_universes.story_id = stories.id and story_universes.universe_id = ${gid}))`)
       }
     }
 
     if (tag !== undefined && typeof tag === 'string') {
       conditions.push(sql`${stories.tags}::jsonb @> ${JSON.stringify([tag])}::jsonb`)
+    }
+
+    if (mixedOnly === 'true') {
+      conditions.push(sql`(select count(*) from story_universes where story_universes.story_id = stories.id) >= 2`)
     }
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined
@@ -254,9 +263,11 @@ router.get('/', async (req, res) => {
       if (t.storyId !== null) totalById.set(t.storyId, Number(t.totalUsdMicros ?? 0))
     }
 
+    const universeIdsByStory = await getStoryUniverseIdsBatch(result.map((row) => ({ id: row.id, groupId: row.groupId })))
+
     res.json(result.map((row) => {
       const total = totalById.get(row.id)
-      return { ...toSnakeCase(row), total_usd_micros: total ?? null }
+      return { ...toSnakeCase(row), total_usd_micros: total ?? null, group_ids: universeIdsByStory.get(row.id) ?? [] }
     }))
   } catch (err) {
     console.error('GET /stories failed:', err)
@@ -289,10 +300,14 @@ router.post('/:id/readings', async (req, res) => {
       statusUpdated = true
 
       if (story.groupId) {
-        const universeId = story.groupId
-        void syncUniverseMemory(universeId).catch((err) =>
-          console.error('[auto-synthesize] failed for universe', universeId, err),
-        )
+        const universeIds = await getStoryUniverseIds(storyId, story.groupId)
+
+        if (universeIds.length === 1) {
+          const universeId = universeIds[0]!
+          void syncUniverseMemory(universeId).catch((err) =>
+            console.error('[auto-synthesize] failed for universe', universeId, err),
+          )
+        }
       }
     }
 
@@ -458,9 +473,8 @@ router.post('/:id/approve-plan', validate(approvePlanSchema), async (req, res) =
     }
 
     if (decision.action === 'start_text_phase') {
-      const { universeSystemPrompt, universeContext, styleGuide } = existing.groupId != null
-        ? await loadUniverseContext(existing.groupId)
-        : { universeSystemPrompt: undefined, universeContext: undefined, styleGuide: undefined }
+      const universeIds = await getStoryUniverseIds(storyId, existing.groupId)
+      const { universeSystemPrompt, universeContext, styleGuide } = await loadUniverseContext(universeIds)
       let sashaContext: string | null = null
 
       const [snapshot] = await db
@@ -476,7 +490,7 @@ router.post('/:id/approve-plan', validate(approvePlanSchema), async (req, res) =
 
       await db.update(stories).set({ planFinal: decision.planV1, updatedAt: new Date() }).where(eq(stories.id, storyId))
 
-      triggerTextPhase(storyId, decision.seed, decision.planV1, existing.mode ?? 'manual', universeSystemPrompt, sashaContext, universeContext, styleGuide)
+      triggerTextPhase(storyId, decision.seed, decision.planV1, existing.mode ?? 'manual', universeSystemPrompt, sashaContext, universeContext, styleGuide, universeIds)
     }
 
     res.json(toSnakeCase(existing as Story))
@@ -509,11 +523,10 @@ router.post('/:id/redo-plan', validate(redoPlanSchema), async (req, res) => {
 
     const { reason, model } = req.body as z.infer<typeof redoPlanSchema>
 
-    const { universeSystemPrompt, universeContext, styleGuide } = existing.groupId != null
-      ? await loadUniverseContext(existing.groupId)
-      : { universeSystemPrompt: undefined, universeContext: undefined, styleGuide: undefined }
+    const universeIds = await getStoryUniverseIds(storyId, existing.groupId)
+    const { universeSystemPrompt, universeContext, styleGuide } = await loadUniverseContext(universeIds)
 
-    triggerPlanRedo(storyId, existing.seed, existing.planFinal ?? '', universeSystemPrompt, universeContext, styleGuide, existing.groupId ?? null, reason, model)
+    triggerPlanRedo(storyId, existing.seed, existing.planFinal ?? '', universeSystemPrompt, universeContext, styleGuide, universeIds, reason, model)
 
     res.json({ started: true, storyId })
   } catch (err) {
@@ -555,9 +568,8 @@ router.post('/:id/redo-text', validate(redoTextSchema), async (req, res) => {
       return
     }
 
-    const { universeSystemPrompt, universeContext, styleGuide } = existing.groupId != null
-      ? await loadUniverseContext(existing.groupId)
-      : { universeSystemPrompt: undefined, universeContext: undefined, styleGuide: undefined }
+    const universeIds = await getStoryUniverseIds(storyId, existing.groupId)
+    const { universeSystemPrompt, universeContext, styleGuide } = await loadUniverseContext(universeIds)
     let sashaContext: string | null = null
 
     const { reason, model } = req.body as z.infer<typeof redoTextSchema>
@@ -586,7 +598,7 @@ router.post('/:id/redo-text', validate(redoTextSchema), async (req, res) => {
       sashaContext = snapshot.sashaContext
     }
 
-    triggerTextRewrite(storyId, currentText, existing.planFinal, universeSystemPrompt, universeContext, styleGuide, sashaContext, existing.groupId ?? null, existing.activeTextVersionId ?? null, trimmedReason || undefined, model)
+    triggerTextRewrite(storyId, currentText, existing.planFinal, universeSystemPrompt, universeContext, styleGuide, sashaContext, universeIds, existing.activeTextVersionId ?? null, trimmedReason || undefined, model)
 
     res.json({ started: true, storyId })
   } catch (err) {
@@ -987,16 +999,20 @@ router.post('/:id/apply-plan-patch', validate(applyPlanPatchSchema), async (req,
       .returning()
 
     if (summary && storyRow.groupId) {
-      const [universe] = await db.select().from(storyGroups).where(eq(storyGroups.id, storyRow.groupId))
+      const universeIds = await getStoryUniverseIds(storyId, storyRow.groupId)
 
-      if (universe) {
-        const existing = universe.styleGuideWorks ?? ''
-        const appended = existing ? `${existing}\n- ${summary}` : `- ${summary}`
+      if (universeIds.length === 1) {
+        const [universe] = await db.select().from(storyGroups).where(eq(storyGroups.id, storyRow.groupId))
 
-        await db
-          .update(storyGroups)
-          .set({ styleGuideWorks: appended })
-          .where(eq(storyGroups.id, storyRow.groupId))
+        if (universe) {
+          const existing = universe.styleGuideWorks ?? ''
+          const appended = existing ? `${existing}\n- ${summary}` : `- ${summary}`
+
+          await db
+            .update(storyGroups)
+            .set({ styleGuideWorks: appended })
+            .where(eq(storyGroups.id, storyRow.groupId))
+        }
       }
     }
 
@@ -1065,16 +1081,20 @@ router.post('/:id/apply-text-patch', validate(applyTextPatchSchema), async (req,
       .returning()
 
     if (summary && storyRow.groupId) {
-      const [universe] = await db.select().from(storyGroups).where(eq(storyGroups.id, storyRow.groupId))
+      const universeIds = await getStoryUniverseIds(storyId, storyRow.groupId)
 
-      if (universe) {
-        const existing = universe.styleGuideWorks ?? ''
-        const appended = existing ? `${existing}\n- ${summary}` : `- ${summary}`
+      if (universeIds.length === 1) {
+        const [universe] = await db.select().from(storyGroups).where(eq(storyGroups.id, storyRow.groupId))
 
-        await db
-          .update(storyGroups)
-          .set({ styleGuideWorks: appended })
-          .where(eq(storyGroups.id, storyRow.groupId))
+        if (universe) {
+          const existing = universe.styleGuideWorks ?? ''
+          const appended = existing ? `${existing}\n- ${summary}` : `- ${summary}`
+
+          await db
+            .update(storyGroups)
+            .set({ styleGuideWorks: appended })
+            .where(eq(storyGroups.id, storyRow.groupId))
+        }
       }
     }
 
@@ -1109,6 +1129,7 @@ router.delete('/:id', async (req, res) => {
     await db.delete(storyReadings).where(eq(storyReadings.storyId, storyId))
     await db.delete(modelCalls).where(eq(modelCalls.storyId, storyId))
     await db.delete(storyTextVersions).where(eq(storyTextVersions.storyId, storyId))
+    await db.delete(storyUniverses).where(eq(storyUniverses.storyId, storyId))
     await db.delete(stories).where(eq(stories.id, storyId))
 
     res.status(204).send()

--- a/packages/api/src/routes/story-analysis.ts
+++ b/packages/api/src/routes/story-analysis.ts
@@ -5,6 +5,7 @@ import { runStoryAnalyzer } from '@bedtime/core/pipeline/stages/story-analyzer'
 import { updateStyleGuide } from '@bedtime/core/pipeline/style-guide-updater'
 import { formatParentFeedback } from '@bedtime/core/pipeline/derivers/format-parent-feedback'
 import { runUniverseFactExtractor } from '@bedtime/core/pipeline/stages/universe-fact-extractor'
+import { getStoryUniverseIds } from './story-universe-links'
 
 export interface AnalyzeResult {
   storyAnalysis: string
@@ -59,9 +60,13 @@ export async function analyzeStoryAndLearn(storyId: number): Promise<AnalyzeResu
   }
 
   let suggestionsCreated = 0
+  let styleGuideUpdated = false
 
-  if (story.groupId !== null && story.groupId !== undefined) {
+  const universeIds = await getStoryUniverseIds(storyId, story.groupId)
+
+  if (story.groupId !== null && story.groupId !== undefined && universeIds.length === 1) {
     const groupId = story.groupId
+    styleGuideUpdated = true
 
     console.log(`[analyze] story ${storyId} — updating style guide for group ${groupId}`)
     const [existingChars, parentReview, storyAnnotations] = await Promise.all([
@@ -102,7 +107,7 @@ export async function analyzeStoryAndLearn(storyId: number): Promise<AnalyzeResu
   return {
     storyAnalysis: output.analysis_summary,
     reactionsExtracted: output.extracted_reactions.length,
-    styleGuideUpdated: story.groupId !== null && story.groupId !== undefined,
+    styleGuideUpdated,
     suggestionsCreated,
   }
 }

--- a/packages/api/src/routes/story-ideas.ts
+++ b/packages/api/src/routes/story-ideas.ts
@@ -7,6 +7,7 @@ import { runIdeaSuggester } from '@bedtime/core/pipeline/stages/idea-suggester'
 import { validate } from '../middleware/validate'
 import { DEFAULT_STAGE_MODELS } from '@bedtime/core/pipeline/derivers/stage-defaults'
 import { dispatchAutoPipeline } from './pipeline-dispatch'
+import { setStoryUniverses } from './story-universe-links'
 
 const router = Router({ mergeParams: true })
 
@@ -188,13 +189,14 @@ router.post('/:ideaId/approve', validate(approveSchema), async (req, res) => {
       if (newStory) {
         createdStoryId = newStory.id
 
+        await setStoryUniverses(newStory.id, [universeId])
         await dispatchAutoPipeline({
           storyId: newStory.id,
           seed: idea.seedText,
           universeSystemPrompt: universe?.systemPrompt ?? undefined,
           universeContext: universe?.universeContext ?? undefined,
           styleGuide: universe?.styleGuide ?? undefined,
-          universeId,
+          universeIds: [universeId],
         })
       }
     }

--- a/packages/api/src/routes/story-universe-links.ts
+++ b/packages/api/src/routes/story-universe-links.ts
@@ -1,0 +1,53 @@
+import { eq, inArray } from 'drizzle-orm'
+import { db } from '@bedtime/core/db/client'
+import { storyUniverses } from '@bedtime/core/db/schema'
+
+export const MAX_UNIVERSES_PER_STORY = 4
+
+export async function getStoryUniverseIds(storyId: number, fallbackGroupId?: number | null): Promise<number[]> {
+  const rows = await db
+    .select({ universeId: storyUniverses.universeId })
+    .from(storyUniverses)
+    .where(eq(storyUniverses.storyId, storyId))
+
+  if (rows.length > 0) return rows.map((r) => r.universeId)
+
+  return fallbackGroupId != null ? [fallbackGroupId] : []
+}
+
+export async function getStoryUniverseIdsBatch(stories: Array<{ id: number; groupId: number | null }>): Promise<Map<number, number[]>> {
+  const storyIds = stories.map((s) => s.id)
+  const result = new Map<number, number[]>()
+
+  if (storyIds.length === 0) return result
+
+  const rows = await db
+    .select({ storyId: storyUniverses.storyId, universeId: storyUniverses.universeId })
+    .from(storyUniverses)
+    .where(inArray(storyUniverses.storyId, storyIds))
+
+  for (const r of rows) {
+    const bucket = result.get(r.storyId) ?? []
+    bucket.push(r.universeId)
+    result.set(r.storyId, bucket)
+  }
+
+  for (const s of stories) {
+    if (!result.has(s.id)) {
+      result.set(s.id, s.groupId != null ? [s.groupId] : [])
+    }
+  }
+
+  return result
+}
+
+export async function setStoryUniverses(storyId: number, universeIds: number[]): Promise<void> {
+  const uniqueIds = Array.from(new Set(universeIds))
+
+  if (uniqueIds.length === 0) return
+
+  await db
+    .insert(storyUniverses)
+    .values(uniqueIds.map((universeId) => ({ storyId, universeId })))
+    .onConflictDoNothing()
+}

--- a/packages/api/src/routes/telegram-new-flow.test.ts
+++ b/packages/api/src/routes/telegram-new-flow.test.ts
@@ -34,6 +34,7 @@ vi.mock('@bedtime/core/db/client.js', () => ({
           dbState.insertedStory = values
           return Promise.resolve([{ id: 77 }])
         }),
+        onConflictDoNothing: vi.fn(() => Promise.resolve([])),
       })),
     })),
   },

--- a/packages/api/src/routes/telegram.ts
+++ b/packages/api/src/routes/telegram.ts
@@ -15,6 +15,7 @@ import {
 } from './telegram-format.js'
 import { dispatchAutoPipeline } from './pipeline-dispatch.js'
 import { registerStoryReadyCallback } from './pipeline-notifications.js'
+import { setStoryUniverses } from './story-universe-links.js'
 
 export { deriveIsAuthorizedUser, deriveIdeaFromMessage }
 
@@ -60,13 +61,14 @@ async function insertAndDispatchStory(seedText: string, universeId: number): Pro
 
   const storyId = newStory!.id
 
+  await setStoryUniverses(storyId, [universeId])
   void dispatchAutoPipeline({
     storyId,
     seed: seedText,
     universeSystemPrompt: universe?.systemPrompt ?? undefined,
     universeContext: universe?.universeContext ?? undefined,
     styleGuide: universe?.styleGuide ?? undefined,
-    universeId,
+    universeIds: [universeId],
   }).catch((err) => {
     console.error(`Failed to dispatch auto pipeline for storyId=${storyId}:`, err)
   })

--- a/packages/api/src/routes/topics.ts
+++ b/packages/api/src/routes/topics.ts
@@ -9,6 +9,7 @@ import { DEFAULT_STAGE_MODELS } from '@bedtime/core/pipeline/derivers/stage-defa
 import { validate } from '../middleware/validate'
 import { loadUniverseContext } from './load-universe-context'
 import { dispatchAutoPipeline } from './pipeline-dispatch'
+import { setStoryUniverses } from './story-universe-links'
 
 const router = Router()
 
@@ -167,7 +168,7 @@ router.post('/suggest-combos', validate(suggestCombosSchema), async (req, res) =
     let universeStyleGuide: string | undefined
 
     if (universeId) {
-      const ctx = await loadUniverseContext(universeId)
+      const ctx = await loadUniverseContext([universeId])
       universeContext = ctx.universeContext
       universeStyleGuide = ctx.styleGuide
     }
@@ -238,7 +239,8 @@ router.post('/generate', validate(generateSchema), async (req, res) => {
       .values(orderedTopics.map((t) => ({ storyId: newStory.id, topicId: t.id })))
       .onConflictDoNothing()
 
-    await dispatchAutoPipeline({ storyId: newStory.id, seed: storySeed, universeId })
+    await setStoryUniverses(newStory.id, [universeId])
+    await dispatchAutoPipeline({ storyId: newStory.id, seed: storySeed, universeIds: [universeId] })
 
     res.status(201).json({ storyId: newStory.id })
   } catch (err) {

--- a/packages/api/src/routes/universes.ts
+++ b/packages/api/src/routes/universes.ts
@@ -2,7 +2,7 @@ import { Router } from 'express'
 import { z } from 'zod'
 import { eq, and } from 'drizzle-orm'
 import { db } from '@bedtime/core/db/client'
-import { storyGroups, stories, universeCharacters } from '@bedtime/core/db/schema'
+import { storyGroups, stories, universeCharacters, storyUniverses } from '@bedtime/core/db/schema'
 import type { StoryGroup, NewStoryGroup } from '@bedtime/core/db/types'
 import { validate } from '../middleware/validate'
 import { getPendingSuggestionsCount } from './universe-suggestions'
@@ -189,7 +189,13 @@ router.delete('/:id', async (req, res) => {
       .where(eq(stories.groupId, id))
       .limit(1)
 
-    if (referencingStory) {
+    const [referencingLink] = await db
+      .select({ id: storyUniverses.id })
+      .from(storyUniverses)
+      .where(eq(storyUniverses.universeId, id))
+      .limit(1)
+
+    if (referencingStory || referencingLink) {
       res.status(409).json({ error: 'Universe is referenced by one or more stories' })
       return
     }

--- a/packages/core/src/db/migrations/0044_story_universes.sql
+++ b/packages/core/src/db/migrations/0044_story_universes.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "story_universes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"story_id" integer NOT NULL,
+	"universe_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "story_universes_story_universe_unique" UNIQUE("story_id","universe_id")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "story_universes" ADD CONSTRAINT "story_universes_story_id_stories_id_fk" FOREIGN KEY ("story_id") REFERENCES "public"."stories"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "story_universes" ADD CONSTRAINT "story_universes_universe_id_story_groups_id_fk" FOREIGN KEY ("universe_id") REFERENCES "public"."story_groups"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/core/src/db/migrations/meta/0044_snapshot.json
+++ b/packages/core/src/db/migrations/meta/0044_snapshot.json
@@ -1,0 +1,2767 @@
+{
+  "id": "72c696fb-9141-4c98-8bab-1db83ceeb0dd",
+  "prevId": "672b194d-4a7a-4264-8265-9a7e931634f9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.annotations": {
+      "name": "annotations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_text": {
+          "name": "selected_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_text": {
+          "name": "note_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_start": {
+          "name": "position_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_end": {
+          "name": "position_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'text'"
+        },
+        "text_version_id": {
+          "name": "text_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_summary": {
+          "name": "resolved_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "annotations_story_id_stories_id_fk": {
+          "name": "annotations_story_id_stories_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "stage_models": {
+          "name": "stage_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_diary": {
+      "name": "child_diary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_profiles": {
+      "name": "child_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activities": {
+          "name": "activities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interests": {
+          "name": "interests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dislikes": {
+          "name": "dislikes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favourites": {
+          "name": "favourites",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_reactions": {
+      "name": "child_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enjoyed": {
+          "name": "enjoyed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_funny": {
+          "name": "was_funny",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_scary": {
+          "name": "was_scary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "too_long": {
+          "name": "too_long",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "understood_moral": {
+          "name": "understood_moral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "want_again": {
+          "name": "want_again",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_moment": {
+          "name": "favorite_moment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_character": {
+          "name": "favorite_character",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "child_reactions_story_id_stories_id_fk": {
+          "name": "child_reactions_story_id_stories_id_fk",
+          "tableFrom": "child_reactions",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "child_reactions_story_id_unique": {
+          "name": "child_reactions_story_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "story_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_type": {
+          "name": "feedback_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "structured_feedback": {
+          "name": "structured_feedback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_story_id_stories_id_fk": {
+          "name": "feedback_story_id_stories_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fragments": {
+      "name": "fragments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "universe_id": {
+          "name": "universe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fragments_universe_id_story_groups_id_fk": {
+          "name": "fragments_universe_id_story_groups_id_fk",
+          "tableFrom": "fragments",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "universe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_calls": {
+      "name": "model_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fallback_used": {
+          "name": "fallback_used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tokens_in": {
+          "name": "tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_out": {
+          "name": "tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usd_micros": {
+          "name": "usd_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_calls_story_id_stories_id_fk": {
+          "name": "model_calls_story_id_stories_id_fk",
+          "tableFrom": "model_calls",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "model_calls_model_id_model_catalog_id_fk": {
+          "name": "model_calls_model_id_model_catalog_id_fk",
+          "tableFrom": "model_calls",
+          "tableTo": "model_catalog",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_catalog": {
+      "name": "model_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_by_provider": {
+          "name": "created_by_provider",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_usd_per_million": {
+          "name": "input_usd_per_million",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_usd_per_million": {
+          "name": "output_usd_per_million",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_usd_per_request": {
+          "name": "image_usd_per_request",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'text->text'"
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[\"text\"]'::jsonb"
+        },
+        "tokenizer": {
+          "name": "tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruct_type": {
+          "name": "instruct_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_json_schema": {
+          "name": "supports_json_schema",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_free": {
+          "name": "is_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_moderated": {
+          "name": "is_moderated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recommended_for_prose": {
+          "name": "is_recommended_for_prose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "popularity_rank": {
+          "name": "popularity_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_swap_events": {
+      "name": "model_swap_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_model": {
+          "name": "from_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_model": {
+          "name": "to_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_chip": {
+          "name": "reason_chip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_text": {
+          "name": "reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_swap_events_story_id_stories_id_fk": {
+          "name": "model_swap_events_story_id_stories_id_fk",
+          "tableFrom": "model_swap_events",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "model_swap_events_from_model_model_catalog_id_fk": {
+          "name": "model_swap_events_from_model_model_catalog_id_fk",
+          "tableFrom": "model_swap_events",
+          "tableTo": "model_catalog",
+          "columnsFrom": [
+            "from_model"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "model_swap_events_to_model_model_catalog_id_fk": {
+          "name": "model_swap_events_to_model_model_catalog_id_fk",
+          "tableFrom": "model_swap_events",
+          "tableTo": "model_catalog",
+          "columnsFrom": [
+            "to_model"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_reviews": {
+      "name": "parent_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pacing_ok": {
+          "name": "pacing_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "would_reuse": {
+          "name": "would_reuse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "parent_reviews_story_id_stories_id_fk": {
+          "name": "parent_reviews_story_id_stories_id_fk",
+          "tableFrom": "parent_reviews",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "parent_reviews_story_id_unique": {
+          "name": "parent_reviews_story_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "story_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_conversations": {
+      "name": "plan_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_conversations_story_id_stories_id_fk": {
+          "name": "plan_conversations_story_id_stories_id_fk",
+          "tableFrom": "plan_conversations",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_questions": {
+      "name": "plan_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer_options": {
+          "name": "answer_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_text": {
+          "name": "answer_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_questions_story_id_stories_id_fk": {
+          "name": "plan_questions_story_id_stories_id_fk",
+          "tableFrom": "plan_questions",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompts": {
+      "name": "prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "change_reason": {
+          "name": "change_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_feedbacks": {
+          "name": "source_feedbacks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_snapshots": {
+      "name": "run_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plotter_model": {
+          "name": "plotter_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plotter_prompt_version": {
+          "name": "plotter_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "psychologist_plan_model": {
+          "name": "psychologist_plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "psychologist_plan_prompt_version": {
+          "name": "psychologist_plan_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plot_critic_model": {
+          "name": "plot_critic_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plot_critic_prompt_version": {
+          "name": "plot_critic_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_model": {
+          "name": "writer_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_prompt_version": {
+          "name": "writer_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "psychologist_text_model": {
+          "name": "psychologist_text_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "psychologist_text_prompt_version": {
+          "name": "psychologist_text_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_critic_model": {
+          "name": "writer_critic_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_critic_prompt_version": {
+          "name": "writer_critic_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_iterations_count": {
+          "name": "plan_iterations_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_v1": {
+          "name": "plan_v1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_final": {
+          "name": "plan_final",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "psychologist_plan_output": {
+          "name": "psychologist_plan_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plot_critic_output": {
+          "name": "plot_critic_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_v1": {
+          "name": "text_v1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_v2": {
+          "name": "text_v2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "psychologist_text_output": {
+          "name": "psychologist_text_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_critic_output": {
+          "name": "writer_critic_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "sasha_context": {
+          "name": "sasha_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "run_snapshots_story_id_stories_id_fk": {
+          "name": "run_snapshots_story_id_stories_id_fk",
+          "tableFrom": "run_snapshots",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stories": {
+      "name": "stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text_final": {
+          "name": "text_final",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_v1": {
+          "name": "plan_v1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_final": {
+          "name": "plan_final",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_iterations": {
+          "name": "plan_iterations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "text_v1": {
+          "name": "text_v1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_v2": {
+          "name": "text_v2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plotter_model": {
+          "name": "plotter_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plotter_prompt_version": {
+          "name": "plotter_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plot_critic_model": {
+          "name": "plot_critic_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plot_critic_prompt_version": {
+          "name": "plot_critic_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_model": {
+          "name": "writer_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_prompt_version": {
+          "name": "writer_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_critic_model": {
+          "name": "writer_critic_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writer_critic_prompt_version": {
+          "name": "writer_critic_prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'agent'"
+        },
+        "is_legacy": {
+          "name": "is_legacy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "discussion_questions": {
+          "name": "discussion_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "seed": {
+          "name": "seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_change_summary": {
+          "name": "plan_change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "text_change_summary": {
+          "name": "text_change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "story_analysis": {
+          "name": "story_analysis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_overrides": {
+          "name": "agent_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "active_text_version_id": {
+          "name": "active_text_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structure_key": {
+          "name": "structure_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens_key": {
+          "name": "lens_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stories_group_id_story_groups_id_fk": {
+          "name": "stories_group_id_story_groups_id_fk",
+          "tableFrom": "stories",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_comments": {
+      "name": "story_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "universe_id": {
+          "name": "universe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_text": {
+          "name": "comment_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_text": {
+          "name": "selected_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chat'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_comments_story_id_stories_id_fk": {
+          "name": "story_comments_story_id_stories_id_fk",
+          "tableFrom": "story_comments",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "story_comments_universe_id_story_groups_id_fk": {
+          "name": "story_comments_universe_id_story_groups_id_fk",
+          "tableFrom": "story_comments",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "universe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_fragments": {
+      "name": "story_fragments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fragment_id": {
+          "name": "fragment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_fragments_story_id_stories_id_fk": {
+          "name": "story_fragments_story_id_stories_id_fk",
+          "tableFrom": "story_fragments",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "story_fragments_fragment_id_fragments_id_fk": {
+          "name": "story_fragments_fragment_id_fragments_id_fk",
+          "tableFrom": "story_fragments",
+          "tableTo": "fragments",
+          "columnsFrom": [
+            "fragment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "story_fragments_story_fragment_unique": {
+          "name": "story_fragments_story_fragment_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "story_id",
+            "fragment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_groups": {
+      "name": "story_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "universe_context": {
+          "name": "universe_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_guide": {
+          "name": "style_guide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_guide_works": {
+          "name": "style_guide_works",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_guide_doesnt_work": {
+          "name": "style_guide_doesnt_work",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_guide_techniques": {
+          "name": "style_guide_techniques",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_guide_minimize": {
+          "name": "style_guide_minimize",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_guide_synced_at": {
+          "name": "style_guide_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_overrides": {
+          "name": "agent_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_ideas": {
+      "name": "story_ideas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "universe_id": {
+          "name": "universe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed_text": {
+          "name": "seed_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idea_suggester_model": {
+          "name": "idea_suggester_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_ideas_universe_id_story_groups_id_fk": {
+          "name": "story_ideas_universe_id_story_groups_id_fk",
+          "tableFrom": "story_ideas",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "universe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_readings": {
+      "name": "story_readings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_readings_story_id_stories_id_fk": {
+          "name": "story_readings_story_id_stories_id_fk",
+          "tableFrom": "story_readings",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_text_versions": {
+      "name": "story_text_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_text_versions_story_id_stories_id_fk": {
+          "name": "story_text_versions_story_id_stories_id_fk",
+          "tableFrom": "story_text_versions",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_topics": {
+      "name": "story_topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_topics_story_id_stories_id_fk": {
+          "name": "story_topics_story_id_stories_id_fk",
+          "tableFrom": "story_topics",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "story_topics_topic_id_topics_id_fk": {
+          "name": "story_topics_topic_id_topics_id_fk",
+          "tableFrom": "story_topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "story_topics_story_topic_unique": {
+          "name": "story_topics_story_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "story_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_universes": {
+      "name": "story_universes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "universe_id": {
+          "name": "universe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_universes_story_id_stories_id_fk": {
+          "name": "story_universes_story_id_stories_id_fk",
+          "tableFrom": "story_universes",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "story_universes_universe_id_story_groups_id_fk": {
+          "name": "story_universes_universe_id_story_groups_id_fk",
+          "tableFrom": "story_universes",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "universe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "story_universes_story_universe_unique": {
+          "name": "story_universes_story_universe_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "story_id",
+            "universe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.story_words": {
+      "name": "story_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "word_id": {
+          "name": "word_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "story_words_story_id_stories_id_fk": {
+          "name": "story_words_story_id_stories_id_fk",
+          "tableFrom": "story_words",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "story_words_word_id_words_id_fk": {
+          "name": "story_words_word_id_words_id_fk",
+          "tableFrom": "story_words",
+          "tableTo": "words",
+          "columnsFrom": [
+            "word_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "story_words_story_word_unique": {
+          "name": "story_words_story_word_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "story_id",
+            "word_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_pending_actions": {
+      "name": "telegram_pending_actions",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "universe_id": {
+          "name": "universe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_pending_actions_universe_id_story_groups_id_fk": {
+          "name": "telegram_pending_actions_universe_id_story_groups_id_fk",
+          "tableFrom": "telegram_pending_actions",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "universe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "universe_id": {
+          "name": "universe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topics_universe_id_story_groups_id_fk": {
+          "name": "topics_universe_id_story_groups_id_fk",
+          "tableFrom": "topics",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "universe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.universe_characters": {
+      "name": "universe_characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "universe_id": {
+          "name": "universe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "age": {
+          "name": "age",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setting": {
+          "name": "setting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "traits": {
+          "name": "traits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relationships": {
+          "name": "relationships",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "co_occurrence_note": {
+          "name": "co_occurrence_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "universe_characters_universe_id_story_groups_id_fk": {
+          "name": "universe_characters_universe_id_story_groups_id_fk",
+          "tableFrom": "universe_characters",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "universe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.universe_suggestions": {
+      "name": "universe_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "universe_id": {
+          "name": "universe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fact_text": {
+          "name": "fact_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_story_id": {
+          "name": "source_story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "universe_suggestions_universe_id_story_groups_id_fk": {
+          "name": "universe_suggestions_universe_id_story_groups_id_fk",
+          "tableFrom": "universe_suggestions",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "universe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "universe_suggestions_source_story_id_stories_id_fk": {
+          "name": "universe_suggestions_source_story_id_stories_id_fk",
+          "tableFrom": "universe_suggestions",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "source_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.value_for_money_feedback": {
+      "name": "value_for_money_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "value_for_money_feedback_story_id_stories_id_fk": {
+          "name": "value_for_money_feedback_story_id_stories_id_fk",
+          "tableFrom": "value_for_money_feedback",
+          "tableTo": "stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "value_for_money_feedback_story_id_unique": {
+          "name": "value_for_money_feedback_story_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "story_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.words": {
+      "name": "words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "universe_id": {
+          "name": "universe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "words_universe_id_story_groups_id_fk": {
+          "name": "words_universe_id_story_groups_id_fk",
+          "tableFrom": "words",
+          "tableTo": "story_groups",
+          "columnsFrom": [
+            "universe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/src/db/migrations/meta/_journal.json
+++ b/packages/core/src/db/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1784402807644,
       "tag": "0043_rare_changeling",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1785053571195,
+      "tag": "0044_story_universes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -93,6 +93,13 @@ export const stories = pgTable('stories', {
   lensKey: text('lens_key'),
 })
 
+export const storyUniverses = pgTable('story_universes', {
+  id: serial('id').primaryKey(),
+  storyId: integer('story_id').references(() => stories.id).notNull(),
+  universeId: integer('universe_id').references(() => storyGroups.id).notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+}, (t) => [unique('story_universes_story_universe_unique').on(t.storyId, t.universeId)])
+
 export const fragments = pgTable('fragments', {
   id: serial('id').primaryKey(),
   text: text('text').notNull(),

--- a/packages/core/src/pipeline/load-exemplars.ts
+++ b/packages/core/src/pipeline/load-exemplars.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNotNull, sql } from 'drizzle-orm'
+import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm'
 import { db } from '../db/client'
 import { stories } from '../db/schema'
 
@@ -8,13 +8,13 @@ export interface Exemplar {
 }
 
 export async function loadRandomExemplars(
-  universeId: number | null,
+  universeIds: number[],
   count: number = 2,
 ): Promise<Exemplar[]> {
   const baseFilter = and(eq(stories.isLegacy, true), isNotNull(stories.textFinal))
 
-  const filter = universeId !== null
-    ? and(baseFilter, eq(stories.groupId, universeId))
+  const filter = universeIds.length > 0
+    ? and(baseFilter, inArray(stories.groupId, universeIds))
     : baseFilter
 
   const rows = await db
@@ -24,7 +24,7 @@ export async function loadRandomExemplars(
     .orderBy(sql`RANDOM()`)
     .limit(count)
 
-  if (rows.length === 0 && universeId !== null) {
+  if (rows.length === 0 && universeIds.length > 0) {
     const fallback = await db
       .select({ title: stories.title, textFinal: stories.textFinal })
       .from(stories)

--- a/packages/core/src/pipeline/load-fragments.ts
+++ b/packages/core/src/pipeline/load-fragments.ts
@@ -6,11 +6,11 @@ import type { EligibleFragment } from './fragments-prompt'
 export * from './fragments-prompt'
 
 export async function loadEligibleFragments(
-  universeId: number | null,
+  universeIds: number[],
   limit: number = 12,
 ): Promise<EligibleFragment[]> {
-  const scopeFilter = universeId !== null
-    ? or(isNull(fragments.universeId), eq(fragments.universeId, universeId))
+  const scopeFilter = universeIds.length > 0
+    ? or(isNull(fragments.universeId), inArray(fragments.universeId, universeIds))
     : isNull(fragments.universeId)
 
   const usedCount = sql<number>`(

--- a/packages/core/src/pipeline/load-memorable-moments.test.ts
+++ b/packages/core/src/pipeline/load-memorable-moments.test.ts
@@ -24,10 +24,10 @@ describe('loadMemorableMoments', () => {
     mockRows = []
   })
 
-  it('returns an empty list when universeId is null, without querying the db', async () => {
+  it('returns an empty list when universeIds is empty, without querying the db', async () => {
     mockRows = [{ type: 'sasha_loved', selectedText: 'момент', noteText: null, storyTitle: null }]
 
-    const result = await loadMemorableMoments(null)
+    const result = await loadMemorableMoments([])
 
     expect(result).toEqual([])
   })
@@ -35,7 +35,7 @@ describe('loadMemorableMoments', () => {
   it('returns an empty list when the universe has no qualifying rows', async () => {
     mockRows = []
 
-    const result = await loadMemorableMoments(1)
+    const result = await loadMemorableMoments([1])
 
     expect(result).toEqual([])
   })
@@ -46,7 +46,7 @@ describe('loadMemorableMoments', () => {
       { type: 'sasha_laughed', selectedText: 'Мира упала в лужу', noteText: null, storyTitle: 'Прогулка' },
     ]
 
-    const result = await loadMemorableMoments(1)
+    const result = await loadMemorableMoments([1])
 
     expect(result).toHaveLength(2)
     expect(result[0]).toEqual({
@@ -57,10 +57,18 @@ describe('loadMemorableMoments', () => {
     })
   })
 
+  it('combines rows across multiple mixed universes', async () => {
+    mockRows = [{ type: 'sasha_loved', selectedText: 'Гоша нашёл рыбку', noteText: null, storyTitle: 'Рыбка' }]
+
+    const result = await loadMemorableMoments([1, 2])
+
+    expect(result).toHaveLength(1)
+  })
+
   it('drops rows with a null selectedText', async () => {
     mockRows = [{ type: 'sasha_loved', selectedText: null, noteText: null, storyTitle: null }]
 
-    const result = await loadMemorableMoments(1)
+    const result = await loadMemorableMoments([1])
 
     expect(result).toEqual([])
   })

--- a/packages/core/src/pipeline/load-memorable-moments.ts
+++ b/packages/core/src/pipeline/load-memorable-moments.ts
@@ -9,15 +9,15 @@ const MEMORABLE_ANNOTATION_TYPES = ['sasha_laughed', 'sasha_loved'] as const
 const CANDIDATE_QUERY_LIMIT = MAX_MEMORABLE_MOMENTS * 4
 
 export async function loadMemorableMoments(
-  universeId: number | null,
+  universeIds: number[],
   excludeStoryId?: number,
 ): Promise<MemorableMomentRow[]> {
-  if (universeId === null) {
+  if (universeIds.length === 0) {
     return []
   }
 
   const conditions = [
-    eq(stories.groupId, universeId),
+    inArray(stories.groupId, universeIds),
     inArray(annotations.type, MEMORABLE_ANNOTATION_TYPES),
     isNotNull(annotations.selectedText),
     ...(excludeStoryId !== undefined ? [ne(annotations.storyId, excludeStoryId)] : []),

--- a/packages/core/src/pipeline/load-reaction-preferences.ts
+++ b/packages/core/src/pipeline/load-reaction-preferences.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from 'drizzle-orm'
+import { desc, eq, inArray } from 'drizzle-orm'
 import { db } from '../db/client'
 import { childReactions, stories } from '../db/schema'
 import {
@@ -11,9 +11,9 @@ import {
 export * from './stages/reaction-preferences'
 
 export async function loadReactionPreferences(
-  universeId: number | null,
+  universeIds: number[],
 ): Promise<ReactionSummary> {
-  if (universeId === null) {
+  if (universeIds.length === 0) {
     return summarizeReactions([])
   }
 
@@ -29,7 +29,7 @@ export async function loadReactionPreferences(
     })
     .from(childReactions)
     .innerJoin(stories, eq(childReactions.storyId, stories.id))
-    .where(eq(stories.groupId, universeId))
+    .where(inArray(stories.groupId, universeIds))
     .orderBy(desc(childReactions.createdAt))
     .limit(REACTION_WINDOW)
 

--- a/packages/core/src/pipeline/load-words.ts
+++ b/packages/core/src/pipeline/load-words.ts
@@ -1,4 +1,4 @@
-import { eq, isNull, or, sql } from 'drizzle-orm'
+import { inArray, isNull, or, sql } from 'drizzle-orm'
 import { db } from '../db/client'
 import { words, storyWords } from '../db/schema'
 import type { TargetWord } from './stages/words-block'
@@ -6,11 +6,11 @@ import type { TargetWord } from './stages/words-block'
 export * from './stages/words-block'
 
 export async function loadEligibleWords(
-  universeId: number | null,
+  universeIds: number[],
   limit: number = 12,
 ): Promise<TargetWord[]> {
-  const scopeFilter = universeId !== null
-    ? or(isNull(words.universeId), eq(words.universeId, universeId))
+  const scopeFilter = universeIds.length > 0
+    ? or(isNull(words.universeId), inArray(words.universeId, universeIds))
     : isNull(words.universeId)
 
   const usedCount = sql<number>`(

--- a/packages/core/src/pipeline/orchestrator.test.ts
+++ b/packages/core/src/pipeline/orchestrator.test.ts
@@ -174,10 +174,10 @@ describe('memorable moments propagation', () => {
       storyId: 1,
       models: baseModels,
       promptVersions: baseVersions,
-      universeId: 42,
+      universeIds: [42],
     })
 
-    expect(loadMemorableMomentsModule.loadMemorableMoments).toHaveBeenCalledWith(42, 1)
+    expect(loadMemorableMomentsModule.loadMemorableMoments).toHaveBeenCalledWith([42], 1)
     const callArgs = vi.mocked(plotterStage.runPlotter).mock.calls[0]?.[0]
     expect(callArgs?.memorableMoments).toEqual([moment])
   })
@@ -191,7 +191,7 @@ describe('memorable moments propagation', () => {
       storyId: 1,
       models: baseModels,
       promptVersions: baseVersions,
-      universeId: 42,
+      universeIds: [42],
     })
 
     const callArgs = vi.mocked(plotterStage.runPlotter).mock.calls[0]?.[0]
@@ -208,10 +208,10 @@ describe('memorable moments propagation', () => {
       storyId: 1,
       models: baseModels,
       promptVersions: baseVersions,
-      universeId: 42,
+      universeIds: [42],
     })
 
-    expect(loadMemorableMomentsModule.loadMemorableMoments).toHaveBeenCalledWith(42, 1)
+    expect(loadMemorableMomentsModule.loadMemorableMoments).toHaveBeenCalledWith([42], 1)
     const callArgs = vi.mocked(writerStage.runWriter).mock.calls[0]?.[0]
     expect(callArgs?.memorableMoments).toEqual([moment])
   })
@@ -226,7 +226,7 @@ describe('memorable moments propagation', () => {
       storyId: 1,
       models: baseModels,
       promptVersions: baseVersions,
-      universeId: 42,
+      universeIds: [42],
     })
 
     const callArgs = vi.mocked(writerStage.runWriter).mock.calls[0]?.[0]

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -82,7 +82,7 @@ export async function runPlanPhase(options: {
   styleGuide?: string
   sashaContext?: string | null
   userFeedback?: string
-  universeId?: number | null
+  universeIds?: number[]
   injectFragments?: boolean
   bibleCharacters?: CharacterBibleEntry[]
   cwd?: string
@@ -113,11 +113,12 @@ export async function runPlanPhase(options: {
 
   const userFeedbackArg = options.userFeedback ? { userFeedback: options.userFeedback } : {}
   const storyIdArg = { storyId: options.storyId }
+  const universeIds = options.universeIds ?? []
 
   const [eligibleFragments, reactionSummary, memorableMoments, structureChoice] = await Promise.all([
-    options.injectFragments ? loadEligibleFragments(options.universeId ?? null) : Promise.resolve([]),
-    options.universeId != null ? loadReactionPreferences(options.universeId) : Promise.resolve(null),
-    loadMemorableMoments(options.universeId ?? null, options.storyId),
+    options.injectFragments ? loadEligibleFragments(universeIds) : Promise.resolve([]),
+    loadReactionPreferences(universeIds),
+    loadMemorableMoments(universeIds, options.storyId),
     resolveStoryStructureChoice(options.storyId),
   ])
   const fragmentsArg = eligibleFragments.length > 0 ? { eligibleFragments } : {}
@@ -182,7 +183,7 @@ export async function runTextPhase(options: {
   styleGuide?: string
   sashaContext?: string | null
   exemplars?: Exemplar[]
-  universeId?: number | null
+  universeIds?: number[]
   cwd?: string
   onStepChange?: (step: string) => void
 }): Promise<TextPhaseResult> {
@@ -220,7 +221,7 @@ export async function runTextPhase(options: {
   const storyIdArg = { storyId: options.storyId }
 
   const [memorableMoments, structureChoice] = await Promise.all([
-    loadMemorableMoments(options.universeId ?? null, options.storyId),
+    loadMemorableMoments(options.universeIds ?? [], options.storyId),
     resolveStoryStructureChoice(options.storyId),
   ])
   const memorableMomentsArg = memorableMoments.length > 0 ? { memorableMoments } : {}
@@ -261,7 +262,7 @@ export async function runPlotterOnly(options: {
   styleGuide?: string
   sashaContext?: string | null
   userFeedback?: string
-  universeId?: number | null
+  universeIds?: number[]
   injectFragments?: boolean
   bibleCharacters?: CharacterBibleEntry[]
   cwd?: string
@@ -284,11 +285,12 @@ export async function runPlotterOnly(options: {
   }
 
   const storyIdArg = { storyId: options.storyId }
+  const universeIds = options.universeIds ?? []
 
   const [eligibleFragments, reactionSummary, memorableMoments, structureChoice] = await Promise.all([
-    options.injectFragments ? loadEligibleFragments(options.universeId ?? null) : Promise.resolve([]),
-    options.universeId != null ? loadReactionPreferences(options.universeId) : Promise.resolve(null),
-    loadMemorableMoments(options.universeId ?? null, options.storyId),
+    options.injectFragments ? loadEligibleFragments(universeIds) : Promise.resolve([]),
+    loadReactionPreferences(universeIds),
+    loadMemorableMoments(universeIds, options.storyId),
     resolveStoryStructureChoice(options.storyId),
   ])
   const fragmentsArg = eligibleFragments.length > 0 ? { eligibleFragments } : {}
@@ -354,7 +356,7 @@ export async function runWriterOnly(options: {
   targetWords?: TargetWord[]
   previousText?: string
   userAnnotations?: string
-  universeId?: number | null
+  universeIds?: number[]
   cwd?: string
   onStepChange?: (step: string) => void
   onChunk?: (chunk: string) => void
@@ -385,7 +387,7 @@ export async function runWriterOnly(options: {
   const storyIdArg = { storyId: options.storyId }
 
   const [memorableMoments, structureChoice] = await Promise.all([
-    loadMemorableMoments(options.universeId ?? null, options.storyId),
+    loadMemorableMoments(options.universeIds ?? [], options.storyId),
     resolveStoryStructureChoice(options.storyId),
   ])
   const memorableMomentsArg = memorableMoments.length > 0 ? { memorableMoments } : {}

--- a/packages/core/src/pipeline/stages/plotter.ts
+++ b/packages/core/src/pipeline/stages/plotter.ts
@@ -112,7 +112,7 @@ export async function runPlotter(options: {
     : ''
 
   const universeContextBlock = options.universeContext
-    ? `\n\n---\nКОНТЕКСТ ВСЕЛЕННОЙ (персонажи, события, темы этой вселенной):\n${options.universeContext}\n---\n`
+    ? `\n\n---\nКОНТЕКСТ ВСЕЛЕННОЙ (персонажи, события, темы вселенной или вселенных истории):\n${options.universeContext}\n---\n`
     : ''
 
   const styleGuideBlock = options.styleGuide

--- a/packages/core/src/pipeline/stages/plotter.ts
+++ b/packages/core/src/pipeline/stages/plotter.ts
@@ -47,6 +47,7 @@ One sentence: what real-life situation does this story address for Sasha (6-year
 ПЕРСОНАЖИ
 2–4 characters. One line each: name, key trait, role in the story. At least one should be funny or quirky.
 At least one character must hold an opposing view to Gosha and maintain it across several scenes — not cave immediately.
+At least one side character besides Gosha and Mira (from the universe's character notes, or a background figure consistent with the seed) must reveal a small, concrete detail about themselves during the story — a habit, an interest, a specific thing they say or do. Not just their name and role in the plot.
 
 МЕСТО И ВРЕМЯ
 One sentence. Familiar or mildly fantastical. Calming for bedtime.

--- a/packages/core/src/pipeline/stages/writer.ts
+++ b/packages/core/src/pipeline/stages/writer.ts
@@ -62,7 +62,7 @@ export async function runWriter(options: {
     : resolved.text
 
   const universeContextBlock = options.universeContext
-    ? `\n\n---\nКОНТЕКСТ ВСЕЛЕННОЙ (персонажи, события, темы этой вселенной):\n${options.universeContext}\n---\n`
+    ? `\n\n---\nКОНТЕКСТ ВСЕЛЕННОЙ (персонажи, события, темы вселенной или вселенных истории):\n${options.universeContext}\n---\n`
     : ''
 
   const styleGuideBlock = options.styleGuide

--- a/packages/web/src/components/create-story-form.test.ts
+++ b/packages/web/src/components/create-story-form.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   validateCreateStoryForm,
   INITIAL_CREATE_STORY_FORM,
+  MAX_UNIVERSES_PER_STORY,
   type CreateStoryFormState,
 } from './create-story-form'
 
@@ -10,38 +11,51 @@ function formWith(overrides: Partial<CreateStoryFormState>): CreateStoryFormStat
 }
 
 describe('validateCreateStoryForm', () => {
-  it('accepts a valid seed with a universe and always uses auto mode', () => {
-    const result = validateCreateStoryForm(formWith({ seed: 'A hero learns patience', groupId: 1 }))
+  it('accepts a valid seed with a single universe and always uses auto mode', () => {
+    const result = validateCreateStoryForm(formWith({ seed: 'A hero learns patience', groupIds: [1] }))
 
-    expect(result).toEqual({ valid: true, input: { seed: 'A hero learns patience', pipelineMode: 'auto', groupId: 1 } })
+    expect(result).toEqual({ valid: true, input: { seed: 'A hero learns patience', pipelineMode: 'auto', groupIds: [1] } })
+  })
+
+  it('accepts a valid seed with multiple universes mixed together', () => {
+    const result = validateCreateStoryForm(formWith({ seed: 'A hero learns patience', groupIds: [1, 2, 3] }))
+
+    expect(result).toEqual({ valid: true, input: { seed: 'A hero learns patience', pipelineMode: 'auto', groupIds: [1, 2, 3] } })
+  })
+
+  it('accepts a valid seed with no universe selected', () => {
+    const result = validateCreateStoryForm(formWith({ seed: 'A hero learns patience', groupIds: [] }))
+
+    expect(result).toEqual({ valid: true, input: { seed: 'A hero learns patience', pipelineMode: 'auto' } })
   })
 
   it('trims the seed before returning', () => {
-    const result = validateCreateStoryForm(formWith({ seed: '   brave bear   ', groupId: 1 }))
+    const result = validateCreateStoryForm(formWith({ seed: '   brave bear   ', groupIds: [1] }))
 
-    expect(result).toEqual({ valid: true, input: { seed: 'brave bear', pipelineMode: 'auto', groupId: 1 } })
+    expect(result).toEqual({ valid: true, input: { seed: 'brave bear', pipelineMode: 'auto', groupIds: [1] } })
   })
 
   it('rejects an empty seed', () => {
-    const result = validateCreateStoryForm(formWith({ seed: '   ', groupId: 1 }))
+    const result = validateCreateStoryForm(formWith({ seed: '   ', groupIds: [1] }))
 
     expect(result.valid).toBe(false)
   })
 
   it('rejects a seed longer than 5000 characters', () => {
-    const result = validateCreateStoryForm(formWith({ seed: 'A'.repeat(5001), groupId: 1 }))
+    const result = validateCreateStoryForm(formWith({ seed: 'A'.repeat(5001), groupIds: [1] }))
 
     expect(result.valid).toBe(false)
   })
 
-  it('rejects when no universe is selected', () => {
-    const result = validateCreateStoryForm(formWith({ seed: 'valid seed', groupId: null }))
+  it('rejects more universes than the mixing limit', () => {
+    const tooMany = Array.from({ length: MAX_UNIVERSES_PER_STORY + 1 }, (_, i) => i + 1)
+    const result = validateCreateStoryForm(formWith({ seed: 'valid seed', groupIds: tooMany }))
 
     expect(result.valid).toBe(false)
   })
 
   it('omits structureKey and lensKey when left on Auto', () => {
-    const result = validateCreateStoryForm(formWith({ seed: 'valid seed', groupId: 1 }))
+    const result = validateCreateStoryForm(formWith({ seed: 'valid seed', groupIds: [1] }))
 
     if (!result.valid) {
       throw new Error('expected valid result')
@@ -53,7 +67,7 @@ describe('validateCreateStoryForm', () => {
 
   it('forwards an explicit structureKey and lensKey when chosen', () => {
     const result = validateCreateStoryForm(
-      formWith({ seed: 'valid seed', groupId: 1, structureKey: 'snowball', lensKey: 'gosha-errs' }),
+      formWith({ seed: 'valid seed', groupIds: [1], structureKey: 'snowball', lensKey: 'gosha-errs' }),
     )
 
     expect(result).toEqual({
@@ -61,7 +75,7 @@ describe('validateCreateStoryForm', () => {
       input: {
         seed: 'valid seed',
         pipelineMode: 'auto',
-        groupId: 1,
+        groupIds: [1],
         structureKey: 'snowball',
         lensKey: 'gosha-errs',
       },

--- a/packages/web/src/components/create-story-form.ts
+++ b/packages/web/src/components/create-story-form.ts
@@ -1,15 +1,17 @@
 import type { CreateStoryInput } from '../lib/api'
 
+export const MAX_UNIVERSES_PER_STORY = 4
+
 export interface CreateStoryFormState {
   seed: string
-  groupId: number | null
+  groupIds: number[]
   structureKey: string | null
   lensKey: string | null
 }
 
 export const INITIAL_CREATE_STORY_FORM: CreateStoryFormState = {
   seed: '',
-  groupId: null,
+  groupIds: [],
   structureKey: null,
   lensKey: null,
 }
@@ -29,8 +31,8 @@ export function validateCreateStoryForm(state: CreateStoryFormState): CreateStor
     return { valid: false, reason: 'Seed is too long' }
   }
 
-  if (state.groupId === null) {
-    return { valid: false, reason: 'Universe is required' }
+  if (state.groupIds.length > MAX_UNIVERSES_PER_STORY) {
+    return { valid: false, reason: `Choose at most ${MAX_UNIVERSES_PER_STORY} universes` }
   }
 
   return {
@@ -38,7 +40,7 @@ export function validateCreateStoryForm(state: CreateStoryFormState): CreateStor
     input: {
       seed,
       pipelineMode: 'auto',
-      groupId: state.groupId,
+      ...(state.groupIds.length > 0 ? { groupIds: state.groupIds } : {}),
       ...(state.structureKey ? { structureKey: state.structureKey } : {}),
       ...(state.lensKey ? { lensKey: state.lensKey } : {}),
     },

--- a/packages/web/src/components/create-story-modal.tsx
+++ b/packages/web/src/components/create-story-modal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { api, type CreateStoryInput, type StoryGroup } from '../lib/api'
 import {
   validateCreateStoryForm,
+  MAX_UNIVERSES_PER_STORY,
   type CreateStoryFormState,
 } from './create-story-form'
 import FormField from './form-field'
@@ -23,21 +24,30 @@ function toDisplayLabel(title: string): string {
   return title.charAt(0) + title.slice(1).toLowerCase()
 }
 
-function loadLastUniverseId(): number | null {
+function loadLastUniverseIds(): number[] {
   try {
     const raw = localStorage.getItem(LAST_UNIVERSE_KEY)
-    return raw ? Number(raw) : null
+
+    if (!raw) return []
+
+    const parsed: unknown = JSON.parse(raw)
+
+    if (Array.isArray(parsed)) return parsed.filter((id): id is number => typeof id === 'number')
+
+    if (typeof parsed === 'number') return [parsed]
+
+    return []
   } catch {
-    return null
+    return []
   }
 }
 
-function saveLastUniverseId(id: number | null) {
+function saveLastUniverseIds(ids: number[]) {
   try {
-    if (id === null) {
+    if (ids.length === 0) {
       localStorage.removeItem(LAST_UNIVERSE_KEY)
     } else {
-      localStorage.setItem(LAST_UNIVERSE_KEY, String(id))
+      localStorage.setItem(LAST_UNIVERSE_KEY, JSON.stringify(ids))
     }
   } catch {
   }
@@ -46,7 +56,7 @@ function saveLastUniverseId(id: number | null) {
 function CreateStoryModal({ open, onClose, onSubmit, onSeriesCreated, initialSeed = '', initialGroupId = null }: CreateStoryModalProps) {
   const [form, setForm] = useState<CreateStoryFormState>({
     seed: initialSeed,
-    groupId: initialGroupId ?? loadLastUniverseId(),
+    groupIds: initialGroupId != null ? [initialGroupId] : loadLastUniverseIds(),
     structureKey: null,
     lensKey: null,
   })
@@ -62,7 +72,7 @@ function CreateStoryModal({ open, onClose, onSubmit, onSeriesCreated, initialSee
     if (open) {
       setForm({
         seed: initialSeed,
-        groupId: initialGroupId ?? loadLastUniverseId(),
+        groupIds: initialGroupId != null ? [initialGroupId] : loadLastUniverseIds(),
         structureKey: null,
         lensKey: null,
       })
@@ -97,7 +107,7 @@ function CreateStoryModal({ open, onClose, onSubmit, onSeriesCreated, initialSee
 
     try {
       await onSubmit(validation.input)
-      setForm({ seed: '', groupId: null, structureKey: null, lensKey: null })
+      setForm({ seed: '', groupIds: [], structureKey: null, lensKey: null })
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : 'Не удалось создать историю')
     } finally {
@@ -116,8 +126,12 @@ function CreateStoryModal({ open, onClose, onSubmit, onSeriesCreated, initialSee
       const created = await api.universes.create({ name, systemPrompt: '.' })
 
       setUniverses((prev) => [...prev, created])
-      saveLastUniverseId(created.id)
-      setForm((prev) => ({ ...prev, groupId: created.id }))
+
+      setForm((prev) => {
+        const groupIds = prev.groupIds.includes(created.id) ? prev.groupIds : [...prev.groupIds, created.id]
+        saveLastUniverseIds(groupIds)
+        return { ...prev, groupIds }
+      })
       setShowCreateUniverse(false)
       setNewUniverseName('')
     } catch {
@@ -135,7 +149,14 @@ function CreateStoryModal({ open, onClose, onSubmit, onSeriesCreated, initialSee
       return
     }
 
-    if (!('seed' in validation.input) || form.groupId === null) {
+    if (form.groupIds.length > 1) {
+      setError('Серия пока поддерживает только одну вселенную — оставь только одну галочку')
+      return
+    }
+
+    const [primaryGroupId] = form.groupIds
+
+    if (!('seed' in validation.input) || primaryGroupId === undefined) {
       setError('Укажи затравку и вселенную')
       return
     }
@@ -144,9 +165,9 @@ function CreateStoryModal({ open, onClose, onSubmit, onSeriesCreated, initialSee
     setError(null)
 
     try {
-      const result = await api.stories.createSeries({ seed: form.seed.trim(), groupId: form.groupId })
+      const result = await api.stories.createSeries({ seed: form.seed.trim(), groupId: primaryGroupId })
 
-      setForm({ seed: '', groupId: null, structureKey: null, lensKey: null })
+      setForm({ seed: '', groupIds: [], structureKey: null, lensKey: null })
       onSeriesCreated?.(result.stories.length)
       onClose()
     } catch (seriesError) {
@@ -164,7 +185,7 @@ function CreateStoryModal({ open, onClose, onSubmit, onSeriesCreated, initialSee
         <h2 className="font-serif text-3xl text-base-content">Новая история</h2>
 
         <div className="mt-5 space-y-5">
-          <FormField label="Вселенная" required>
+          <FormField label="Вселенная" hint="Необязательно. Можно выбрать несколько — их персонажи и стиль смешаются в истории.">
             {showCreateUniverse ? (
               <div className="flex gap-2">
                 <input
@@ -205,28 +226,42 @@ function CreateStoryModal({ open, onClose, onSubmit, onSeriesCreated, initialSee
                 )}
               </div>
             ) : (
-              <div className="flex gap-2">
-                <select
-                  className="select select-bordered flex-1 bg-base-200"
-                  value={form.groupId ?? ''}
-                  onChange={(event) => {
-                    const value = event.target.value
-                    const groupId = value === '' ? null : parseInt(value, 10)
+              <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-1 rounded-lg border border-base-300 bg-base-200 p-2 max-h-48 overflow-y-auto">
+                  {universes.length === 0 && (
+                    <p className="px-1 py-1 text-sm text-base-content/50">Нет ни одной вселенной</p>
+                  )}
+                  {universes.map((u) => {
+                    const checked = form.groupIds.includes(u.id)
+                    const atLimit = !checked && form.groupIds.length >= MAX_UNIVERSES_PER_STORY
 
-                    saveLastUniverseId(groupId)
-                    setForm((prev) => ({ ...prev, groupId }))
-                  }}
-                >
-                  <option value="" disabled>Выбери вселенную...</option>
-                  {universes.map((u) => (
-                    <option key={u.id} value={u.id}>
-                      {u.name}
-                    </option>
-                  ))}
-                </select>
+                    return (
+                      <label
+                        key={u.id}
+                        className={`label cursor-pointer justify-start gap-2 rounded px-1 py-1 hover:bg-base-300 ${atLimit ? 'opacity-50' : ''}`}
+                      >
+                        <input
+                          type="checkbox"
+                          className="checkbox checkbox-sm"
+                          checked={checked}
+                          disabled={atLimit}
+                          onChange={(event) => {
+                            const groupIds = event.target.checked
+                              ? [...form.groupIds, u.id]
+                              : form.groupIds.filter((id) => id !== u.id)
+
+                            saveLastUniverseIds(groupIds)
+                            setForm((prev) => ({ ...prev, groupIds }))
+                          }}
+                        />
+                        <span className="label-text">{u.name}</span>
+                      </label>
+                    )
+                  })}
+                </div>
                 <button
                   type="button"
-                  className="btn btn-ghost btn-sm text-primary"
+                  className="btn btn-ghost btn-sm self-start text-primary"
                   onClick={() => setShowCreateUniverse(true)}
                 >
                   + Новая

--- a/packages/web/src/components/story-card.tsx
+++ b/packages/web/src/components/story-card.tsx
@@ -18,7 +18,7 @@ interface StoryCardProps {
   rating?: number
   seriesId?: string | null
   totalUsdMicros?: number | null
-  universeName?: string
+  universeNames?: string[]
   actions?: StoryCardAction[]
   onTitleClick?: () => void
   dragHandleProps?: HTMLAttributes<HTMLDivElement>
@@ -76,11 +76,12 @@ function GripIcon() {
   )
 }
 
-function StoryCard({ title, status, createdAt, rating, seriesId, totalUsdMicros, universeName, actions = [], onTitleClick, dragHandleProps }: StoryCardProps) {
+function StoryCard({ title, status, createdAt, rating, seriesId, totalUsdMicros, universeNames = [], actions = [], onTitleClick, dragHandleProps }: StoryCardProps) {
   const config = statusConfig[status]
   const isArchived = status === 'archived'
   const regularActions = actions.filter((action) => action.tone !== 'destructive')
   const destructiveActions = actions.filter((action) => action.tone === 'destructive')
+  const isMixed = universeNames.length > 1
 
   return (
     <article
@@ -115,6 +116,9 @@ function StoryCard({ title, status, createdAt, rating, seriesId, totalUsdMicros,
             <div className="flex shrink-0 gap-1">
               {seriesId && (
                 <span className="badge badge-sm badge-outline" title="Часть серии историй">Серия</span>
+              )}
+              {isMixed && (
+                <span className="badge badge-sm badge-outline" title={universeNames.join(' + ')}>Микс</span>
               )}
               <span className={`badge badge-sm ${config.tone}`}>{config.label}</span>
             </div>

--- a/packages/web/src/components/story-filters.tsx
+++ b/packages/web/src/components/story-filters.tsx
@@ -18,6 +18,7 @@ export interface StoryFilterState {
   groupId: number | null
   tag: string | null
   sort: SortOption
+  mixedOnly: boolean
 }
 
 export const DEFAULT_FILTERS: StoryFilterState = {
@@ -25,6 +26,7 @@ export const DEFAULT_FILTERS: StoryFilterState = {
   groupId: null,
   tag: null,
   sort: 'custom',
+  mixedOnly: false,
 }
 
 const STORED_FILTERS_KEY = 'story-list-filters-v2'
@@ -36,6 +38,7 @@ const storedFiltersSchema = z.object({
   sort: z
     .enum(['custom', 'created_desc', 'created_asc', 'updated_desc', 'ready_desc', 'newest_read', 'oldest_read'])
     .default('custom'),
+  mixedOnly: z.boolean().default(false),
 })
 
 export function loadStoredFilters(): StoryFilterState {
@@ -78,6 +81,8 @@ export function activeFilterCount(f: StoryFilterState): number {
 
   if (f.sort !== 'custom') count++
 
+  if (f.mixedOnly) count++
+
   return count
 }
 
@@ -86,7 +91,8 @@ export function hasCustomFilters(f: StoryFilterState): boolean {
     f.status !== DEFAULT_FILTERS.status ||
     f.groupId !== DEFAULT_FILTERS.groupId ||
     f.tag !== DEFAULT_FILTERS.tag ||
-    f.sort !== DEFAULT_FILTERS.sort
+    f.sort !== DEFAULT_FILTERS.sort ||
+    f.mixedOnly !== DEFAULT_FILTERS.mixedOnly
   )
 }
 
@@ -152,10 +158,10 @@ function StoryFilters({ value, onChange, universes, availableTags, lockedStatus 
   }, [])
 
   const count = lockedStatus
-    ? (value.groupId !== null ? 1 : 0) + (value.tag !== null ? 1 : 0) + (value.sort !== 'custom' ? 1 : 0)
+    ? (value.groupId !== null ? 1 : 0) + (value.tag !== null ? 1 : 0) + (value.sort !== 'custom' ? 1 : 0) + (value.mixedOnly ? 1 : 0)
     : activeFilterCount(value)
   const hasActive = lockedStatus
-    ? value.groupId !== null || value.tag !== null || value.sort !== 'custom'
+    ? value.groupId !== null || value.tag !== null || value.sort !== 'custom' || value.mixedOnly
     : hasCustomFilters(value)
   const activeUniverse = value.groupId !== null ? universes.find((u) => u.id === value.groupId) : null
 
@@ -219,6 +225,18 @@ function StoryFilters({ value, onChange, universes, availableTags, lockedStatus 
               </div>
             )}
 
+            <div className="mb-4">
+              <label className="label cursor-pointer justify-start gap-2 px-0">
+                <input
+                  type="checkbox"
+                  className="checkbox checkbox-sm"
+                  checked={value.mixedOnly}
+                  onChange={(e) => onChange({ ...value, mixedOnly: e.target.checked })}
+                />
+                <span className="label-text">Только миксы вселенных</span>
+              </label>
+            </div>
+
             {availableTags.length > 0 && (
               <div className="mb-4">
                 <p className="mb-2 text-xs font-medium uppercase tracking-wide text-base-content/50">Категория</p>
@@ -272,6 +290,13 @@ function StoryFilters({ value, onChange, universes, availableTags, lockedStatus 
         <FilterChip
           label={`#${value.tag}`}
           onRemove={() => onChange({ ...value, tag: null })}
+        />
+      )}
+
+      {value.mixedOnly && (
+        <FilterChip
+          label="Миксы"
+          onRemove={() => onChange({ ...value, mixedOnly: false })}
         />
       )}
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -126,6 +126,7 @@ export interface Story {
   is_legacy: boolean
   discussion_questions: string[] | null
   group_id: number | null
+  group_ids: number[]
   plan_change_summary: string | null
   mode: 'auto' | 'manual'
   text_change_summary: string | null
@@ -355,6 +356,7 @@ export type CreateStoryInput =
   | {
       seed: string
       groupId?: number
+      groupIds?: number[]
       pipelineMode?: 'auto' | 'manual'
       perStageOverrides?: PerStageOverrides
       structureKey?: string
@@ -456,13 +458,14 @@ export interface PipelineStatus {
 
 export const api = {
   stories: {
-    list: (filters?: { status?: string; groupId?: number; tag?: string; sort?: string }) => {
+    list: (filters?: { status?: string; groupId?: number; tag?: string; sort?: string; mixedOnly?: boolean }) => {
       const params = new URLSearchParams()
 
       if (filters?.status) params.set('status', filters.status)
       if (filters?.groupId != null) params.set('groupId', String(filters.groupId))
       if (filters?.tag) params.set('tag', filters.tag)
       if (filters?.sort && filters.sort !== 'custom') params.set('sort', filters.sort)
+      if (filters?.mixedOnly) params.set('mixedOnly', 'true')
 
       const query = params.toString() ? `?${params.toString()}` : ''
 

--- a/packages/web/src/pages/inbox.tsx
+++ b/packages/web/src/pages/inbox.tsx
@@ -41,7 +41,7 @@ function Section({
               title={item.story.title}
               status={item.story.status}
               createdAt={item.story.created_at}
-              universeName={universes.find((u) => u.id === item.story.group_id)?.name}
+              universeNames={item.story.group_ids.map((id) => universes.find((u) => u.id === id)?.name).filter((n): n is string => n != null)}
               actions={[
                 {
                   label: actionLabel(item.action),

--- a/packages/web/src/pages/story-list.tsx
+++ b/packages/web/src/pages/story-list.tsx
@@ -44,12 +44,12 @@ const PAGE_META: Record<string, { eyebrow: string; title: string; description: s
 
 interface SortableStoryCardProps {
   story: Story
-  universeName?: string
+  universeNames?: string[]
   onTitleClick: () => void
   onDelete: () => void
 }
 
-function SortableStoryCard({ story, universeName, onTitleClick, onDelete }: SortableStoryCardProps) {
+function SortableStoryCard({ story, universeNames, onTitleClick, onDelete }: SortableStoryCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: story.id,
   })
@@ -70,7 +70,7 @@ function SortableStoryCard({ story, universeName, onTitleClick, onDelete }: Sort
         createdAt={story.created_at}
         seriesId={story.series_id}
         totalUsdMicros={story.total_usd_micros ?? null}
-        universeName={universeName}
+        universeNames={universeNames}
         onTitleClick={onTitleClick}
         dragHandleProps={{ ...listeners, ...attributes }}
         actions={[
@@ -143,6 +143,7 @@ export function StoryListPage({ lockedStatus }: { lockedStatus?: StatusFilter })
         groupId: effectiveFilters.groupId ?? undefined,
         tag: effectiveFilters.tag ?? undefined,
         sort: effectiveFilters.sort !== 'custom' ? effectiveFilters.sort : undefined,
+        mixedOnly: effectiveFilters.mixedOnly || undefined,
       })
 
       setStories(data)
@@ -266,7 +267,7 @@ export function StoryListPage({ lockedStatus }: { lockedStatus?: StatusFilter })
                 <SortableStoryCard
                   key={story.id}
                   story={story}
-                  universeName={universes.find((u) => u.id === story.group_id)?.name}
+                  universeNames={story.group_ids.map((id) => universes.find((u) => u.id === id)?.name).filter((n): n is string => n != null)}
                   onTitleClick={() => navigate(`/stories/${story.id}`)}
                   onDelete={() => handleDeleteStory(story)}
                 />


### PR DESCRIPTION
## Summary
- Universe selection is now optional and supports picking several universes (up to 4) to blend into one story, via a new `story_universes` join table alongside the existing primary `group_id`.
- Story cards now show a mix badge when a story blends universes, and the story list can filter to mixed-only stories.
- Fixed a bug where deleting a universe only checked the old single `group_id` column, letting a universe still in use as a secondary mix-in be deleted and leaving orphaned data.
- Every generated story plan now also has to reveal a small concrete detail about a side character besides Gosha and Mira.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx vitest run` — all tests pass
- [x] Verified live against the `local-dev` Neon branch: create story with 0/1/multiple universes, 4-universe cap enforced, blended prompts, legacy single-universe fallback, mix badge/filter data, universe delete guard blocking a secondary-mix-in delete