### PR TITLE
Fix CI test crash from broken import in create-story-schema

### DIFF
--- a/packages/api/src/routes/create-story-schema.ts
+++ b/packages/api/src/routes/create-story-schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { PIPELINE_STAGES, PipelineStage } from '@bedtime/core/pipeline/pipeline-stages'
 import { getStoryStructureByKey } from '@bedtime/core/pipeline/stages/story-structures'
 import { getCharacterLensByKey } from '@bedtime/core/pipeline/stages/character-lenses'
-import { MAX_UNIVERSES_PER_STORY } from './story-universe-links'
+import { MAX_UNIVERSES_PER_STORY } from './story-universe-limits'
 
 const stageOverrideSchema = z.object({
   model: z.string().min(1),

--- a/packages/api/src/routes/story-universe-limits.ts
+++ b/packages/api/src/routes/story-universe-limits.ts
@@ -1,0 +1,1 @@
+export const MAX_UNIVERSES_PER_STORY = 4

--- a/packages/api/src/routes/story-universe-links.ts
+++ b/packages/api/src/routes/story-universe-links.ts
@@ -2,8 +2,6 @@ import { eq, inArray } from 'drizzle-orm'
 import { db } from '@bedtime/core/db/client'
 import { storyUniverses } from '@bedtime/core/db/schema'
 
-export const MAX_UNIVERSES_PER_STORY = 4
-
 export async function getStoryUniverseIds(storyId: number, fallbackGroupId?: number | null): Promise<number[]> {
   const rows = await db
     .select({ universeId: storyUniverses.universeId })


### PR DESCRIPTION
## Summary
- PR #299 broke the CI test job: `create-story-schema.ts` imported `MAX_UNIVERSES_PER_STORY` from `story-universe-links.ts`, which imports the db client and parses required env vars at module load. Those secrets aren't available in the test job (only the deploy job), so any test importing the schema module crashed on import before running a single assertion.
- Moved the constant into its own dependency-free module so schema validation no longer needs a database connection to be testable.

## Test plan
- [x] Reproduced the CI failure locally by running `vitest` with `DATABASE_URL`/`OPENROUTER_API_KEY`/`JWT_SECRET` unset — confirmed it now passes
- [x] Full suite (`vitest run`) passes with those env vars unset — 70/70 files, 491/491 tests
- [x] `npm run typecheck` clean