### PR TITLE
Fix web build failure from incomplete universeName rename

### DIFF
--- a/packages/web/src/components/story-card.tsx
+++ b/packages/web/src/components/story-card.tsx
@@ -127,7 +127,7 @@ function StoryCard({ title, status, createdAt, rating, seriesId, totalUsdMicros,
           <div className="flex items-center justify-between gap-3 text-xs text-base-content/65">
             <span>
               {formatDate(createdAt)}
-              {universeName && <span className="ml-1.5 text-base-content/40">{universeName}</span>}
+              {universeNames.length > 0 && <span className="ml-1.5 text-base-content/40">{universeNames.join(' + ')}</span>}
             </span>
 
             <span className="flex items-center gap-3">

--- a/packages/web/src/components/story-filters.stories.tsx
+++ b/packages/web/src/components/story-filters.stories.tsx
@@ -81,6 +81,7 @@ export const WithSelectedFilters: Story = {
         groupId: 1,
         tag: 'спокойная',
         sort: 'custom',
+        mixedOnly: false,
       }}
     />
   ),

--- a/packages/web/src/pages/inbox-derivation.test.ts
+++ b/packages/web/src/pages/inbox-derivation.test.ts
@@ -34,6 +34,7 @@ function mkStory(overrides: Partial<Story>): Story {
     is_legacy: false,
     discussion_questions: null,
     group_id: null,
+    group_ids: [],
     plan_change_summary: null,
     mode: 'auto',
     text_change_summary: null,


### PR DESCRIPTION
## Summary
- PR #299's rename from a single `universeName` string to a `universeNames` array missed one usage in `story-card.tsx` and two fixtures (`story-filters.stories.tsx`, `inbox-derivation.test.ts`) that were never updated for the new `group_ids`/`mixedOnly` fields.
- The repo-root `npm run typecheck` didn't catch this because its tsconfig's `include` list only covers `packages/core`, `packages/api`, and `packages/shared` — `packages/web` is checked separately, only as part of `npm run build:web` (which is what the Docker production build actually runs). That's a pre-existing gap in the typecheck script, not something this PR changes.

## Test plan
- [x] `cd packages/web && npx tsc --noEmit` clean
- [x] `npm run build:web` succeeds (the same command the Docker build runs)
- [x] `npm run typecheck` clean, full `vitest run` passes with DB env vars unset (70/70 files, 491/491 tests)