### PR TITLE
Add request timeout and failure notification to story pipeline

### DIFF
--- a/.planning/gh226-pipeline-timeout-auto-failure/spec.md
+++ b/.planning/gh226-pipeline-timeout-auto-failure/spec.md
@@ -1,0 +1,64 @@
+---
+type: spec
+branch: pipeline-stuck-job-timeout
+task: "Stuck Story Job Timeout and Auto-Failure (GH #226)"
+complexity: simple
+state: confirmed
+updated: 2026-07-29
+---
+# Spec: Stuck story job timeout and auto-failure
+
+### What to do
+
+**Root cause, verified in code:** `packages/core/src/openrouter/openrouter.client.ts` makes raw `fetch()` calls to OpenRouter with no timeout, no `AbortController`. A hung or non-responding provider request can wait indefinitely. This is why a story generation can get stuck with no resolution — not a missing "detect stuck jobs" sweep, but the actual network call never settling in the first place. Confirming this was the intended design and not an oversight: `openrouter.runner.ts`'s `isRetryable()` already special-cases error messages containing `'timeout'` as retryable — the retry path was built expecting timeouts to happen, but nothing ever produced one.
+
+Two things production already has that reduce the blast radius, so this is a targeted fix, not a redesign:
+- Cloud Tasks (`PIPELINE_QUEUE`, confirmed configured in `.github/workflows/deploy.yml`) dispatches pipeline runs as real queued HTTP tasks with a 900s `dispatchDeadline`, and the worker handler (`packages/api/src/routes/internal-worker.ts`) `await`s the full pipeline inside the request — so a crashed/restarted instance mid-run already gets retried by Cloud Tasks. A separate DB-persisted-status sweep would duplicate this, not add real coverage.
+- The existing `catch` blocks in `pipeline-auto-trigger.ts` / `pipeline-text-trigger.ts` already set `plan_failed` / `text_failed` — once something actually throws, the failure path is already correct. It just never gets triggered by a hang, only by an outright error.
+
+What's genuinely missing, and what this spec fixes:
+1. A bounded timeout on every OpenRouter HTTP call, so a hang always resolves to a real, retryable error within a sane window instead of waiting forever.
+2. A Telegram notification when the auto pipeline's plan or text phase ultimately fails (all retries exhausted) — today nothing tells the parent a story failed; the only signal is a story that silently never finishes and an ephemeral in-memory status that vanishes on process restart and isn't visible unless they happen to have the live status page open at that exact moment.
+
+### Decisions made autonomously
+
+1. **Per-request timeout of 180 seconds (3 minutes).** The Writer stage generates full story text (`minOutputTokens: 4000` per `recommend-model.ts`) and is the slowest call — 180s is generous for that while still bounded well inside Cloud Tasks' 900s overall dispatch deadline, leaving room for the existing retry/fallback loop to use its normal backoff after a timeout. Reversible — a single constant.
+2. **Timeout applies to all three `OpenRouterClient` methods** (`listModels`, `chatNonStream`, `chatStream`), not just the structured-output path, since `listModels` (catalog sync) and streaming (interactive writer/rewrite flows) can hang exactly the same way.
+3. **On timeout, throw an `Error` whose message contains `'timeout'`**, so the existing `isRetryable()` classification picks it up with zero changes to the runner's retry logic — the retry path already expects this shape of error.
+4. **Failure notification only for `mode === 'auto'`**, mirroring the existing success-notification behavior (`notifyStoryReady` is also only called `if (isAuto)`). Manual/redo flows are already synchronous from the parent's perspective (they're watching the live status page when they triggered it), so a push notification adds no value there — only auto-pipeline runs (which can happen while the parent isn't watching, e.g. triggered from Telegram and then the phone is put away) need a proactive nudge.
+5. **No new DB column, no new scheduled sweep.** As reasoned above, Cloud Tasks' own retry-on-failure already covers the crash/restart case; adding a redundant server-side sweep against `stories` timestamps would duplicate that mechanism for no added reliability, at the cost of real complexity (cross-instance in-memory-status visibility, false-positive risk on scale-to-zero cold starts). Out of scope — flagged below, not silently dropped.
+
+### Files to modify
+
+```
+packages/core/src/openrouter/
+├── openrouter.client.ts   — AbortController + setTimeout (180s, named constant) around all three
+│                             fetch calls; on abort, throw an Error with 'timeout' in the message;
+│                             clear the timeout in a finally so it never leaks
+packages/api/src/routes/
+├── pipeline-notifications.ts  — add notifyStoryFailed(storyId, phase: 'plan' | 'text'), same
+│                                 registerStoryReadyCallback-style pattern as notifyStoryReady
+├── pipeline-auto-trigger.ts   — call notifyStoryFailed in the existing plan-phase catch block
+├── pipeline-text-trigger.ts   — call notifyStoryFailed in the existing text-phase catch block,
+│                                 only when mode === 'auto'
+└── telegram.ts                — register the failure callback, distinct message per phase
+```
+
+### Files to create
+No new files.
+
+### Data model changes
+None.
+
+### Documentation changes
+No documentation changes required — no architectural shift (no new service, no new infra, no schema change). A bug fix to an existing HTTP client plus a notification wired the same way an existing one already is.
+
+### Scope boundary
+Out of scope: a server-side scheduled sweep for stuck jobs (reasoned above as redundant with Cloud Tasks' existing retry); persisting pipeline status to Postgres (the in-memory map's only real weakness — surviving a process restart — is already covered by Cloud Tasks retry, so persisting it doesn't buy additional reliability here); changing Cloud Tasks' own retry count/backoff config (infrastructure already reasonable, not touched by this app-level fix).
+
+### Implementation order
+1. `openrouter.client.ts` — add the timeout to all three fetch call sites.
+2. `pipeline-notifications.ts` — add `notifyStoryFailed`.
+3. `pipeline-auto-trigger.ts` / `pipeline-text-trigger.ts` — call it from the existing catch blocks.
+4. `telegram.ts` — register and message the failure callback.
+5. Typecheck, test, verify.

--- a/packages/api/src/routes/pipeline-auto-trigger.ts
+++ b/packages/api/src/routes/pipeline-auto-trigger.ts
@@ -12,6 +12,7 @@ import { setPipelineStatus, setCurrentStep } from './pipeline-state'
 import { defaultPromptVersions, resolvePipelineModels, loadStoryOverrides } from './pipeline-defaults'
 import { runTextPhaseDurable } from './pipeline-text-trigger'
 import { loadUniverseContext } from './load-universe-context'
+import { notifyStoryFailed } from './pipeline-notifications'
 import { withPipelineTrace } from '@bedtime/observability'
 
 export interface AutoPipelineParams {
@@ -72,6 +73,7 @@ export async function runAutoPipeline(params: AutoPipelineParams): Promise<void>
     } catch (planError) {
       console.error(`Auto pipeline plan phase failed for storyId=${storyId}:`, planError)
       setPipelineStatus(storyId, 'plan_failed')
+      notifyStoryFailed(storyId, 'plan')
       throw planError
     }
 

--- a/packages/api/src/routes/pipeline-notifications.ts
+++ b/packages/api/src/routes/pipeline-notifications.ts
@@ -1,15 +1,28 @@
 export type StoryNotificationStage = 'generated' | 'approved'
+export type StoryFailurePhase = 'plan' | 'text'
 
 type StoryReadyCallback = (storyId: number, stage: StoryNotificationStage) => void
+type StoryFailedCallback = (storyId: number, phase: StoryFailurePhase) => void
 
 let storyReadyCallback: StoryReadyCallback | null = null
+let storyFailedCallback: StoryFailedCallback | null = null
 
 export function registerStoryReadyCallback(fn: StoryReadyCallback): void {
   storyReadyCallback = fn
 }
 
+export function registerStoryFailedCallback(fn: StoryFailedCallback): void {
+  storyFailedCallback = fn
+}
+
 export function notifyStoryReady(storyId: number, stage: StoryNotificationStage = 'approved'): void {
   if (storyReadyCallback) {
     storyReadyCallback(storyId, stage)
+  }
+}
+
+export function notifyStoryFailed(storyId: number, phase: StoryFailurePhase): void {
+  if (storyFailedCallback) {
+    storyFailedCallback(storyId, phase)
   }
 }

--- a/packages/api/src/routes/pipeline-text-trigger.ts
+++ b/packages/api/src/routes/pipeline-text-trigger.ts
@@ -11,7 +11,7 @@ import {
 } from './pipeline-persistence'
 import { getPipelineStatus, setPipelineStatus, setCurrentStep, emitPipelineEvent } from './pipeline-state'
 import { defaultPromptVersions, resolvePipelineModels, loadStoryOverrides } from './pipeline-defaults'
-import { notifyStoryReady } from './pipeline-notifications'
+import { notifyStoryReady, notifyStoryFailed } from './pipeline-notifications'
 import { withPipelineTraceIfNone } from '@bedtime/observability'
 
 export { getPipelineStatus, setPipelineStatus }
@@ -148,6 +148,11 @@ export async function runTextPhaseDurable(params: TextPhaseParams): Promise<void
     })
   } catch (textError) {
     setPipelineStatus(storyId, 'text_failed')
+
+    if (mode === 'auto') {
+      notifyStoryFailed(storyId, 'text')
+    }
+
     throw textError
   }
 }

--- a/packages/api/src/routes/telegram-new-flow.test.ts
+++ b/packages/api/src/routes/telegram-new-flow.test.ts
@@ -58,6 +58,7 @@ vi.mock('./pipeline-dispatch.js', () => ({
 
 vi.mock('./pipeline-notifications.js', () => ({
   registerStoryReadyCallback: vi.fn(),
+  registerStoryFailedCallback: vi.fn(),
 }))
 
 const { bot } = await import('./telegram.js')

--- a/packages/api/src/routes/telegram.ts
+++ b/packages/api/src/routes/telegram.ts
@@ -20,7 +20,7 @@ import {
   pickReadableText,
 } from './telegram-format.js'
 import { dispatchAutoPipeline } from './pipeline-dispatch.js'
-import { registerStoryReadyCallback } from './pipeline-notifications.js'
+import { registerStoryReadyCallback, registerStoryFailedCallback } from './pipeline-notifications.js'
 import { setStoryUniverses } from './story-universe-links.js'
 
 export { deriveIsAuthorizedUser, deriveIdeaFromMessage }
@@ -262,6 +262,22 @@ if (bot) {
       })
       .catch((err) => {
         console.error('[telegram] failed to send story notification:', err)
+      })
+  })
+
+  registerStoryFailedCallback((storyId, phase) => {
+    const message =
+      phase === 'plan'
+        ? `Не получилось придумать план для сказки №${storyId} 😕 Открой /stories и попробуй пересоздать её.`
+        : `План для сказки №${storyId} готов, но текст не получился 😕 Открой /stories и попробуй пересоздать текст.`
+
+    bot!.api
+      .sendMessage(allowedUserId, message)
+      .then(() => {
+        console.log(`[telegram] story failure notification sent for story #${storyId} (phase=${phase})`)
+      })
+      .catch((err) => {
+        console.error('[telegram] failed to send story failure notification:', err)
       })
   })
 

--- a/packages/core/src/openrouter/openrouter.client.test.ts
+++ b/packages/core/src/openrouter/openrouter.client.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { OpenRouterClient } from './openrouter.client'
+
+describe('OpenRouterClient request timeout', () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    global.fetch = originalFetch
+  })
+
+  it('rejects chatNonStream with a timeout error when the provider never responds', async () => {
+    global.fetch = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('This operation was aborted', 'AbortError'))
+        })
+      })
+    }) as unknown as typeof fetch
+
+    const client = new OpenRouterClient('test-key')
+
+    const call = client.chatNonStream({ model: 'test-model', messages: [] })
+    const assertion = expect(call).rejects.toThrow(/timeout/i)
+
+    await vi.advanceTimersByTimeAsync(180_000)
+    await assertion
+  })
+
+  it('rejects listModels with a timeout error when the provider never responds', async () => {
+    global.fetch = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('This operation was aborted', 'AbortError'))
+        })
+      })
+    }) as unknown as typeof fetch
+
+    const client = new OpenRouterClient('test-key')
+
+    const call = client.listModels()
+    const assertion = expect(call).rejects.toThrow(/timeout/i)
+
+    await vi.advanceTimersByTimeAsync(180_000)
+    await assertion
+  })
+
+  it('does not time out a call that resolves well within the limit', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ choices: [{ message: { content: 'hi' } }], usage: {} }),
+      } as Response),
+    ) as unknown as typeof fetch
+
+    const client = new OpenRouterClient('test-key')
+
+    await expect(client.chatNonStream({ model: 'test-model', messages: [] })).resolves.toEqual({
+      text: 'hi',
+      usage: { promptTokens: 0, completionTokens: 0, costUsd: 0 },
+    })
+  })
+})

--- a/packages/core/src/openrouter/openrouter.client.ts
+++ b/packages/core/src/openrouter/openrouter.client.ts
@@ -1,4 +1,20 @@
 const BASE_URL = 'https://openrouter.ai/api/v1'
+const REQUEST_TIMEOUT_MS = 180_000
+
+function withTimeout(): { signal: AbortSignal; clear: () => void } {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(new Error(`OpenRouter request exceeded timeout of ${REQUEST_TIMEOUT_MS}ms`)), REQUEST_TIMEOUT_MS)
+
+  return { signal: controller.signal, clear: () => clearTimeout(timer) }
+}
+
+function toTimeoutError(err: unknown): unknown {
+  if (err instanceof Error && err.name === 'AbortError') {
+    return new Error(`OpenRouter request exceeded timeout of ${REQUEST_TIMEOUT_MS}ms`)
+  }
+
+  return err
+}
 
 export interface OpenRouterUsage {
   promptTokens: number
@@ -43,54 +59,82 @@ export class OpenRouterClient {
   constructor(private readonly apiKey: string) {}
 
   async listModels(): Promise<unknown> {
-    const res = await fetch(`${BASE_URL}/models`, {
-      method: 'GET',
-      headers: authHeaders(this.apiKey),
-    })
+    const { signal, clear } = withTimeout()
 
-    if (!res.ok) {
-      throw new OpenRouterHttpError(res.status, await res.text())
+    try {
+      const res = await fetch(`${BASE_URL}/models`, {
+        method: 'GET',
+        headers: authHeaders(this.apiKey),
+        signal,
+      })
+
+      if (!res.ok) {
+        throw new OpenRouterHttpError(res.status, await res.text())
+      }
+
+      return await res.json()
+    } catch (err) {
+      throw toTimeoutError(err)
+    } finally {
+      clear()
     }
-
-    return res.json()
   }
 
   async chatNonStream(req: ChatRequest): Promise<ChatNonStreamResult> {
     const body = { ...req, stream: false }
-    const res = await fetch(`${BASE_URL}/chat/completions`, {
-      method: 'POST',
-      headers: authHeaders(this.apiKey),
-      body: JSON.stringify(body),
-    })
+    const { signal, clear } = withTimeout()
 
-    if (!res.ok) {
-      throw new OpenRouterHttpError(res.status, await res.text())
+    try {
+      const res = await fetch(`${BASE_URL}/chat/completions`, {
+        method: 'POST',
+        headers: authHeaders(this.apiKey),
+        body: JSON.stringify(body),
+        signal,
+      })
+
+      if (!res.ok) {
+        throw new OpenRouterHttpError(res.status, await res.text())
+      }
+
+      const json = (await res.json()) as {
+        choices?: Array<{ message?: { content?: string } }>
+        usage?: { prompt_tokens?: number; completion_tokens?: number; cost?: number }
+      }
+
+      const text = json.choices?.[0]?.message?.content ?? ''
+      const usage: OpenRouterUsage = {
+        promptTokens: json.usage?.prompt_tokens ?? 0,
+        completionTokens: json.usage?.completion_tokens ?? 0,
+        costUsd: json.usage?.cost ?? 0,
+      }
+
+      return { text, usage }
+    } catch (err) {
+      throw toTimeoutError(err)
+    } finally {
+      clear()
     }
-
-    const json = (await res.json()) as {
-      choices?: Array<{ message?: { content?: string } }>
-      usage?: { prompt_tokens?: number; completion_tokens?: number; cost?: number }
-    }
-
-    const text = json.choices?.[0]?.message?.content ?? ''
-    const usage: OpenRouterUsage = {
-      promptTokens: json.usage?.prompt_tokens ?? 0,
-      completionTokens: json.usage?.completion_tokens ?? 0,
-      costUsd: json.usage?.cost ?? 0,
-    }
-
-    return { text, usage }
   }
 
   async *chatStream(req: ChatRequest): AsyncIterable<ChatStreamEvent> {
     const body = { ...req, stream: true, usage: { include: true } }
-    const res = await fetch(`${BASE_URL}/chat/completions`, {
-      method: 'POST',
-      headers: authHeaders(this.apiKey),
-      body: JSON.stringify(body),
-    })
+    const { signal, clear } = withTimeout()
+
+    let res: Response
+    try {
+      res = await fetch(`${BASE_URL}/chat/completions`, {
+        method: 'POST',
+        headers: authHeaders(this.apiKey),
+        body: JSON.stringify(body),
+        signal,
+      })
+    } catch (err) {
+      clear()
+      throw toTimeoutError(err)
+    }
 
     if (!res.ok || res.body === null) {
+      clear()
       throw new OpenRouterHttpError(res.status, res.body === null ? 'no body' : await res.text())
     }
 
@@ -98,46 +142,56 @@ export class OpenRouterClient {
     const decoder = new TextDecoder('utf-8')
     let buffer = ''
 
-    while (true) {
-      const { value, done } = await reader.read()
-      if (done) break
-      buffer += decoder.decode(value, { stream: true })
-
-      let idx
-      while ((idx = buffer.indexOf('\n')) !== -1) {
-        const line = buffer.slice(0, idx).trim()
-        buffer = buffer.slice(idx + 1)
-
-        if (line === '' || line.startsWith(':')) continue
-        if (!line.startsWith('data:')) continue
-
-        const data = line.slice(5).trim()
-        if (data === '[DONE]') return
-
-        let parsed: {
-          choices?: Array<{ delta?: { content?: string } }>
-          usage?: { prompt_tokens?: number; completion_tokens?: number; cost?: number }
-        }
-
+    try {
+      while (true) {
+        let value: Uint8Array | undefined
+        let done: boolean
         try {
-          parsed = JSON.parse(data)
-        } catch {
-          continue
+          ;({ value, done } = await reader.read())
+        } catch (err) {
+          throw toTimeoutError(err)
         }
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
 
-        const delta = parsed.choices?.[0]?.delta?.content
-        if (delta !== undefined && delta !== '') yield { delta }
+        let idx
+        while ((idx = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, idx).trim()
+          buffer = buffer.slice(idx + 1)
 
-        if (parsed.usage !== undefined) {
-          yield {
-            usage: {
-              promptTokens: parsed.usage.prompt_tokens ?? 0,
-              completionTokens: parsed.usage.completion_tokens ?? 0,
-              costUsd: parsed.usage.cost ?? 0,
-            },
+          if (line === '' || line.startsWith(':')) continue
+          if (!line.startsWith('data:')) continue
+
+          const data = line.slice(5).trim()
+          if (data === '[DONE]') return
+
+          let parsed: {
+            choices?: Array<{ delta?: { content?: string } }>
+            usage?: { prompt_tokens?: number; completion_tokens?: number; cost?: number }
+          }
+
+          try {
+            parsed = JSON.parse(data)
+          } catch {
+            continue
+          }
+
+          const delta = parsed.choices?.[0]?.delta?.content
+          if (delta !== undefined && delta !== '') yield { delta }
+
+          if (parsed.usage !== undefined) {
+            yield {
+              usage: {
+                promptTokens: parsed.usage.prompt_tokens ?? 0,
+                completionTokens: parsed.usage.completion_tokens ?? 0,
+                costUsd: parsed.usage.cost ?? 0,
+              },
+            }
           }
         }
       }
+    } finally {
+      clear()
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bound every OpenRouterClient call (listModels, chatNonStream, chatStream) to a 180s timeout via AbortController, so a hung provider request always resolves to a real, retryable error instead of stalling indefinitely.
- Added a Telegram notification for auto-triggered stories when the plan or text phase ultimately fails after retries, mirroring the existing success notification.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx vitest run` — 548/548 tests pass, including new timeout coverage in `openrouter.client.test.ts`